### PR TITLE
refator widgetOutput to support multi widget packages.

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -68,9 +68,9 @@ toHTML.htmlwidget <- function(x, standalone = FALSE, knitrOptions = NULL, ...){
 }
 
 #' @export
-widgetOutput <- function(x){
+widgetOutput <- function(x, ...){
   if (is.character(x)) {
-    cx <- structure(class = c(x, 'htmlwidget'), list(value = 10))
+    cx <- createWidget(name = x, list(), ...)
     className <- x
   } else {
     cx <- x


### PR DESCRIPTION
This PR refactors `widgetOutput` so that multi widget packages can take advantage of it. There are some issues with this approach as pointed to by @jjallaire 

> One issue here is whether the generation of HTML depends on the "x" value. With the fake widget object the values within "x" won't be available in the Shiny case (because they wait on renderValue to be called). Many users may assume (understandably) that "x" is available and then use it in static cases only to later be surprised by the fact that it doesn't work for Shiny (this is exactly what happened to me).

So if the HTML is dependent on the x value then this approach fails. Now, in most widgets I have authored, the generic `widgetOutput` approach in this PR works. The key question is do we want to provide it in `htmlwidgets`, or is it better leaving it off.
