### PR TITLE
Address some issues related to widgetOutput width/height

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -76,7 +76,7 @@ widgetOutput <- function(x, ...){
     cx <- x
     className <- class(cx)[[1]]
   }
-
+  
   function(outputId, width, height){
     html <- htmltools::tagList(
       widget_html(cx, id = outputId, class = paste(className, "html-widget html-widget-output"), 


### PR DESCRIPTION
1. Provide defaults for width and height arguments (an error occurred without this)
2. Alias arguments (a recursive default argument error occurred without this)
3. Use validateCssUnit to accept various forms of width and height
