### PR TITLE
allow specification of viewer pane height

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -1,6 +1,31 @@
 #' @export
 print.htmlwidget <- function(x, ...) {
-  print(browsable(htmltools::as.tags(x, standalone=TRUE)), ...)
+ 
+  # if we have a viewer then forward viewer pane height (if any)
+  viewer <- getOption("viewer")
+  if (!is.null(viewer)) {
+    viewerFunc <- function(url) {
+      
+      # get the requested pane height (it defaults to NULL)
+      paneHeight <- x$sizingPolicy$viewer$paneHeight
+      
+      # convert maximize to -1 for compatibility with older versions of rstudio
+      # (newer versions convert 'maximize' to -1 interally, older versions
+      # will simply ignore the height if it's less than zero)
+      if (identical(paneHeight, "maximize")) 
+        paneHeight <- -1 
+      
+      # call the viewer
+      viewer(url, height = paneHeight)
+    }
+  } else {
+    viewerFunc <- utils::browseURL
+  }
+  
+  # call html_print with the viewer
+  html_print(htmltools::as.tags(x, standalone=TRUE), viewer = viewerFunc)
+  
+  # return value
   invisible(x)
 }
 

--- a/R/sizing.R
+++ b/R/sizing.R
@@ -10,6 +10,7 @@ sizingPolicy <- function(
   defaultWidth = NULL, defaultHeight = NULL, padding = NULL,
   viewer.defaultWidth = NULL, viewer.defaultHeight = NULL,
   viewer.padding = NULL, viewer.fill = TRUE, viewer.suppress = FALSE,
+  viewer.paneHeight = NULL,
   browser.defaultWidth = NULL, browser.defaultHeight = NULL,
   browser.padding = NULL, browser.fill = FALSE,
   knitr.defaultWidth = NULL, knitr.defaultHeight = NULL,
@@ -24,7 +25,8 @@ sizingPolicy <- function(
       defaultHeight = viewer.defaultHeight,
       padding = viewer.padding,
       fill = viewer.fill,
-      suppress = viewer.suppress
+      suppress = viewer.suppress,
+      paneHeight = viewer.paneHeight
     ),
     browser = list(
       defaultWidth = browser.defaultWidth,


### PR DESCRIPTION
Enable component authors to specify an explicit viewer pane height as part of their sizingPolicy (this would most commonly be used to request either a fully maximized or nearly maximized height).
