### PR TITLE
set version to 0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.0
+Version: 0.2.1
 Date: 2014-07-17
 Author: Ramnath Vaidyanathan, Joe Cheng, and JJ Allaire
 Maintainer: Ramnath Vaidyanathan <ramnath.vaidya@gmail.com>


### PR DESCRIPTION
Setting the version to something lower that 1.0 so that we can periodically bump the version when our packages depend on new or revised functionality. I propose that each CRAN release bump the first decimal (e.g. 0.2, 0.3) and that releases in between bump the 3rd decimal. This is what knitr does, whereas shiny has a 4th decimal in case they want to do an e.g. 0.10.1 release. I'm fine with either approach.
