### PR TITLE
allow user to specify libdir in saveWidget.

### DIFF
--- a/R/savewidget.R
+++ b/R/savewidget.R
@@ -11,13 +11,16 @@
 #'   placed in an adjacent directory.
 #'
 #' @export
-saveWidget <- function(widget, file, selfcontained = TRUE) {
+saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL) {
    
   # convert to HTML tags
   html <- toHTML(widget, standalone = TRUE)
   
   # form a path for dependenent files
-  libdir <- paste(tools::file_path_sans_ext(basename(file)), "_files", sep = "")
+  if (is.null(libdir)){
+    libdir <- paste(tools::file_path_sans_ext(basename(file)), "_files", 
+      sep = "")
+  }
   
   # save the file
   htmltools::save_html(html, file = file, libdir = libdir)


### PR DESCRIPTION
This PR allows a user to specify libdir explicitly, while using `selfcontained = FALSE`. This is useful when creating a directory of examples, allowing them to share dependencies.
