### PR TITLE
to be able to specify one's own JSON converter

### DIFF
--- a/R/htmlwidgets-package.R
+++ b/R/htmlwidgets-package.R
@@ -1,2 +1,2 @@
-#' @import htmltools RJSONIO
+#' @import htmltools
 NULL

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -86,7 +86,7 @@ toHTML.htmlwidget <- function(x, standalone = FALSE, knitrOptions = NULL, ...){
     widget_data(x, id),
     if (!is.null(sizeInfo$runtime)) {
       tags$script(type="application/htmlwidget-sizing", `data-for` = id,
-        toJSON(sizeInfo$runtime, collapse="")
+        toJSON(sizeInfo$runtime)
       )
     }
   )
@@ -120,7 +120,7 @@ widget_dependencies <- function(name, package){
 #' @export
 widget_data <- function(x, id, ...){
   tags$script(type="application/json", `data-for` = id,
-    HTML(toJSON(x$x, collapse = ""))
+    HTML(toJSON(x$x))
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,3 +57,9 @@ any_prop <- function(scopes, path) {
   }
   return(NULL)
 }
+
+toJSON <- function(x) {
+  convert <- attr(x, 'JSON_CONVERTER', exact = TRUE)
+  if (!is.function(convert)) convert <- RJSONIO::toJSON
+  convert(x)
+}


### PR DESCRIPTION
if not specified, use the default `RJSONIO::toJSON()`

This PR should not break existing widgets packages, and frees the package authors from RJSONIO (if they want). Once we have got this capability, the priority of #28 will be low. 