### PR TITLE
Add digits=16 to toJSON calls

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -85,7 +85,7 @@ toHTML <- function(x, standalone = FALSE, knitrOptions = NULL) {
     widget_data(x, id),
     if (!is.null(sizeInfo$runtime)) {
       tags$script(type="application/htmlwidget-sizing", `data-for` = id,
-        toJSON(sizeInfo$runtime, collapse="")
+        toJSON(sizeInfo$runtime, collapse="", digits = 16)
       )
     }
   )
@@ -124,7 +124,7 @@ widget_dependencies <- function(name, package){
 widget_data <- function(x, id, ...){
   evals <- JSEvals(x$x)
   tags$script(type="application/json", `data-for` = id,
-    HTML(toJSON(list(x = x$x, evals = evals), collapse = ""))
+    HTML(toJSON(list(x = x$x, evals = evals), collapse = "", digits = 16))
   )
 }
 

--- a/R/to_json.R
+++ b/R/to_json.R
@@ -20,7 +20,7 @@ to_json = function(df, orient = "columns", json = TRUE){
     values = do.call('zip_vectors_', setNames(dl, NULL))
   )
   if (json){
-    dl = RJSONIO::toJSON(dl)
+    dl = RJSONIO::toJSON(dl, digits = 16)
   }
   return(dl)
 }


### PR DESCRIPTION
Without this, the precision is too low to use Leaflet maps at city-level zoom levels.
