### PR TITLE
handle more bower cases with bower install in scaffoldWidget

### DIFF
--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -157,8 +157,10 @@ addWidgetJS <- function(name, edit){
 # This function uses bower to install a javascript package along with
 # its dependencies.
 installBowerPkg <- function(pkg){
+  bowerPath = findBower()
+
   # check if bower is installed
-  if (findBower() == ""){
+  if (is.null(bowerPath) || bowerPath == ""){
     stop(
       "Please install bower from http://bower.io",
       call. = FALSE


### PR DESCRIPTION
**Nice but certainly nothing to delay or interfere with CRAN submission**

As I tested alternate cases with [bower](http://bower.io/#install-bower), I ran into problems, since these [lines in `readBower`](https://github.com/timelyportfolio/htmlwidgets/blob/master/R/scaffold.R#L202-L204) assume the primary and popular use case of `bower install` with a package in the bower registry.  The alternate unpopular but potentially problematic cases would be Github shorthand or a direct Github url.  I added a tiny bit of code to handle these cases by using `basename()` and also removing `".git"`.
