### PR TITLE
add tooltip to static sigma graph in intro to insure it gets seen

### DIFF
--- a/develop_intro.Rmd
+++ b/develop_intro.Rmd
@@ -36,7 +36,7 @@ data <- system.file("examples/ediaspora.gexf.xml", package = "sigma")
 sigma(data)
 ```
 
-![sigma](images/sigma.png)
+<img src="images/sigma.png" alt="sigma" data-toggle="tooltip" data-placement="right" title="" data-original-title="Note this is just an image of the visualization so it's not interactive. You can play with the interactive version by following the steps in the demo section below." onload="$(this).tooltip()">
 
 Note that the above is just an image of the visualization so it's not interactive. You can play with the interactive version by following the steps in the demo section below. 
 


### PR DESCRIPTION
This should definitely be classified as a small thing, but since the focus of widgets is interactivity, I would very much like to make sure readers see that the static sigma graph is static only because we intentionally made it static.  I changed the `img` to use the tooltip functionality from cosmo.css, so that on hover, the tooltip appears with the message that had been below the `img` in `p` in the original.  I only made the change in the markdown and did not rebuild for this pull to isolate the change.

![image](https://cloud.githubusercontent.com/assets/837910/5456287/12d02066-8508-11e4-8838-8dcd522c8b91.png)
