### PR TITLE
fixes timelyportfolio/parcoords#6: make sure data.evals is an array

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -376,6 +376,7 @@
       overrideMethod(shinyBinding, "renderValue", function(superfunc) {
         return function(el, data) {
           // Resolve strings marked as javascript literals to objects
+          if (!(data.evals instanceof Array)) data.evals = [data.evals];
           for (var i = 0; data.evals && i < data.evals.length; i++) {
             window.HTMLWidgets.evaluateStringMember(data.x, data.evals[i]);
           }
@@ -469,6 +470,7 @@
         if (scriptData) {
           var data = JSON.parse(scriptData.textContent || scriptData.text);
           // Resolve strings marked as javascript literals to objects
+          if (!(data.evals instanceof Array)) data.evals = [data.evals];
           for (var k = 0; data.evals && k < data.evals.length; k++) {
             window.HTMLWidgets.evaluateStringMember(data.x, data.evals[k]);
           }


### PR DESCRIPTION
toJSON() in the current development version of shiny will unbox data.evals to a scalar, and we just make sure it is an array on the JavaScript side

note this PR should be safe to merge even before we switch to jsonlite in htmlwidgets, i.e. it does not hurt RJSONIO