### PR TITLE
should not use i in the inner loop, because the top-level loop also uses i

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -469,8 +469,8 @@
         if (scriptData) {
           var data = JSON.parse(scriptData.textContent || scriptData.text);
           // Resolve strings marked as javascript literals to objects
-          for (var i = 0; data.evals && i < data.evals.length; i++) {
-            window.HTMLWidgets.evaluateStringMember(data.x, data.evals[i]);
+          for (var k = 0; data.evals && k < data.evals.length; k++) {
+            window.HTMLWidgets.evaluateStringMember(data.x, data.evals[k]);
           }
           binding.renderValue(el, data.x, initResult);
         }


### PR DESCRIPTION
e.g. when data.evals.length == 1, i will be 1 by the end of this loop due to i++; then i will become 2 due to i++ from the outer loop, and the outer loop will exit early

here is a simplified minimal example, in which we expect i to be printed twice in the outer loop:

```js
for (var i = 0; i < 2; i++) {
  console.log('outer loop i = ' + i);
  for (var i = 0; i < 1; i++) {
  }
  console.log('inner loop i = ' + i);
}
// outer loop i = 0
// inner loop i = 1
// i = 2 now
```

fixes rstudio/DT#25