### PR TITLE
Removed and in Author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: HTML Widgets for R
 Version: 0.3.2
 Date: 2014-12-03
 Author: Ramnath Vaidyanathan, Joe Cheng, JJ Allaire, Yihui Xie,
-    and Kenton Russell
+    Kenton Russell
 Maintainer: JJ Allaire <jj@rstudio.com>
 Description: A framework for creating HTML widgets that render in various
     contexts including the R console, R Markdown documents, and Shiny


### PR DESCRIPTION
The `and` in Author leads to two  `and`s being generated when BibTeX citation is created.