### PR TITLE
Feature/pre render hook

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -158,8 +158,9 @@ widget_data <- function(x, id, ...){
 #'@param elementId Use an explicit element ID for the widget (rather than an
 #'  automatically generated one). Useful if you have other JavaScript that needs
 #'  to explicitly discover and interact with a specific widget instance.
-#'@param preRenderHook A function to be run on the widget payload x, prior to
-#'  rendering.
+#'@param preRenderHook A function to be run on the widget, just prior to
+#'  rendering. It accepts the entire widget object as input, and should return
+#'  a modified widget object.
 #'
 #'@details
 #'

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -287,10 +287,10 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 
 # Helper function to create payload
 createPayload <- function(instance){
-  x <- .subset2(instance, "x")
   if (!is.null(instance$preRenderHook)){
-    x <- instance$preRenderHook(x)
+    instance <- instance$preRenderHook(instance)
   }
+  x <- .subset2(instance, "x")
   evals = JSEvals(x)
   list(x = x, evals = evals)
 }

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -279,7 +279,7 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
       htmltools::resolveDependencies(deps),
       shiny::createWebDependency
     )
-    payload = modifyList(createPayload(instance), list(deps = deps))
+    payload = c(createPayload(instance), list(deps = deps))
   }
 
   # mark it with the output function so we can use it in Rmd files
@@ -290,6 +290,7 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 createPayload <- function(instance){
   if (!is.null(instance$preRenderHook)){
     instance <- instance$preRenderHook(instance)
+    instance$preRenderHook <- NULL
   }
   x <- .subset2(instance, "x")
   evals = JSEvals(x)


### PR DESCRIPTION
This PR adds a `preRenderHook` argument to `createWidget` to support manipulations of the widget object, just prior to rendering. It was motivated by [this thread](https://github.com/bokeh/rbokeh/issues/25#issuecomment-87831557)

Here is a simple example that explains how it works

```R
devtools::create('newpkg')
setwd('newpkg')
htmlwidgets::scaffoldWidget('testwidget')
```

In the createWidget line of `testwidget`, add the following line

```
createWidget(
  x,
  ...,
  preRenderHook = function(x){ 
    x$x$message = paste("Hi", x$x$message) 
  })
)
```

If you build the package now and run  `testwidget("R"), it will render `Hi R`. It works with Shiny as well.

In the process of adding this feature, I also refactored `widget_data` and `shinyRenderWidget` by spinning common code off to a function called `createPayload`. This would make it easier for changes made to payload processing to permeate to both the static and shiny cases.

@jcheng5, @jjallaire, @yihui, @timelyportfolio Let me know if you have a chance to test this out, and any feedback/comments.