### PR TITLE
Introduce a global option `htmlwidgets.TOJSON_ARGS` to customize toJSON() arguments

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -26,9 +26,9 @@ if (requireNamespace('shiny')) local({
 toJSON <- function(x) {
   if (!is.list(x) || !('x' %in% names(x))) return(toJSON2(x))
   func <- attr(x$x, 'TOJSON_FUNC', exact = TRUE)
-  args <- c(list(x = x), attr(x$x, 'TOJSON_ARGS', exact = TRUE))
+  args <- attr(x$x, 'TOJSON_ARGS', exact = TRUE)
   if (!is.function(func)) func = toJSON2
-  res <- if (length(args) == 0) func(x) else do.call(func, args)
+  res <- if (length(args) == 0) func(x) else do.call(func, c(list(x = x), args))
   # make sure shiny:::toJSON() does not encode it again
   structure(res, class = 'json')
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,6 +28,7 @@ toJSON <- function(x) {
   func <- attr(x$x, 'TOJSON_FUNC', exact = TRUE)
   args <- attr(x$x, 'TOJSON_ARGS', exact = TRUE)
   if (!is.function(func)) func = toJSON2
+  if (length(args) == 0) args <- getOption('htmlwidgets.TOJSON_ARGS')
   res <- if (length(args) == 0) func(x) else do.call(func, c(list(x = x), args))
   # make sure shiny:::toJSON() does not encode it again
   structure(res, class = 'json')

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,8 +27,8 @@ toJSON <- function(x) {
   if (!is.list(x) || !('x' %in% names(x))) return(toJSON2(x))
   func <- attr(x$x, 'TOJSON_FUNC', exact = TRUE)
   args <- attr(x$x, 'TOJSON_ARGS', exact = TRUE)
-  if (!is.function(func)) func = toJSON2
   if (length(args) == 0) args <- getOption('htmlwidgets.TOJSON_ARGS')
+  if (!is.function(func)) func <- toJSON2
   res <- if (length(args) == 0) func(x) else do.call(func, c(list(x = x), args))
   # make sure shiny:::toJSON() does not encode it again
   structure(res, class = 'json')


### PR DESCRIPTION
This is a simple PR that introduces a global option `htmlwidgets.TOJSON_ARGS` to customize `toJSON()` arguments. It makes it easier to customize arguments for a whole project that involves multiple widget packages, e.g. I may want to set `options(htmlwidgets.TOJSON_ARGS = list(pretty = TRUE, digits = 6))` before I build multiple R Markdown documents, so I do not have to change the `toJSON()` arguements in each widget package.

Note the `TOJSON_ARGS` attribute has precedence over the `htmlwidgets.TOJSON_ARGS` option.