### PR TITLE
Check shiny version

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -285,12 +285,12 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 }
 
 checkShinyVersion <- function(error = TRUE) {
-  x <- packageDescription('htmlwidgets', fields = 'Enhances')
+  x <- utils::packageDescription('htmlwidgets', fields = 'Enhances')
   r <- '^.*?shiny \\(>= ([0-9.]+)\\).*$'
   if (is.na(x) || length(grep(r, x)) == 0 || system.file('shiny') == '') return()
   v <- gsub(r, '\\1', x)
   f <- if (error) stop else packageStartupMessage
-  if (packageVersion('shiny') < v)
+  if (utils::packageVersion('shiny') < v)
     f("You have to upgrade the 'shiny' package to (at least) version ", v)
 }
 

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -237,6 +237,7 @@ createWidget <- function(name,
 #' @export
 shinyWidgetOutput <- function(outputId, name, width, height, package = name) {
 
+  checkShinyVersion()
   # generate html
   html <- htmltools::tagList(
     widget_html(name, package, id = outputId,
@@ -258,6 +259,7 @@ shinyWidgetOutput <- function(outputId, name, width, height, package = name) {
 #' @export
 shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 
+  checkShinyVersion()
   # generate a function for the expression
   func <- shiny::exprToFunction(expr, env, quoted)
 
@@ -280,6 +282,16 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 
   # mark it with the output function so we can use it in Rmd files
   shiny::markRenderFunction(outputFunction, renderFunc)
+}
+
+checkShinyVersion <- function(error = TRUE) {
+  x <- packageDescription('htmlwidgets', fields = 'Enhances')
+  r <- '^.*?shiny \\(>= ([0-9.]+)\\).*$'
+  if (is.na(x) || length(grep(r, x)) == 0) return()
+  v <- gsub(r, '\\1', x)
+  f <- if (error) stop else packageStartupMessage
+  if (packageVersion('shiny') < v)
+    f("You have to upgrade the 'shiny' package to (at least) version ", v)
 }
 
 # Helper function to create payload

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -287,7 +287,7 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 checkShinyVersion <- function(error = TRUE) {
   x <- packageDescription('htmlwidgets', fields = 'Enhances')
   r <- '^.*?shiny \\(>= ([0-9.]+)\\).*$'
-  if (is.na(x) || length(grep(r, x)) == 0) return()
+  if (is.na(x) || length(grep(r, x)) == 0 || system.file('shiny') == '') return()
   v <- gsub(r, '\\1', x)
   f <- if (error) stop else packageStartupMessage
   if (packageVersion('shiny') < v)

--- a/R/knitr-methods.R
+++ b/R/knitr-methods.R
@@ -20,6 +20,9 @@ registerMethods <- function(methods) {
 }
 
 .onLoad <- function(...) {
+  # warn if the version of shiny is lower than what was specified in DESCRIPTION
+  checkShinyVersion(error = FALSE)
+
   # htmlwidgets provides methods for knitr::knit_print, but knitr isn't a Depends or
   # Imports of htmltools, only an Enhances. Therefore, the NAMESPACE file has to
   # declare it as an export, not an S3method. That means that R will only know to


### PR DESCRIPTION
I just discussed this with @jcheng5 and @wch, and we thought it'd be a good idea to check the version of shiny in htmlwidgets (and vice versa https://github.com/rstudio/shiny/pull/830), in case users upgraded one package but not the other.

Checking takes place in both `.onLoad()` and `shinyWidgetOutput()`/`shinyRenderWidget()`, so hopefully users should have good chances to see this message.