### PR TITLE
Fix bug where resize() isn't called on some widgets

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -49,6 +49,17 @@
     return target;
   }
 
+  // IE8 doesn't support Array.forEach.
+  function forEach(values, callback, thisArg) {
+    if (values.forEach) {
+      values.forEach(callback, thisArg);
+    } else {
+      for (var i = 0; i < values.length; i++) {
+        callback.call(thisArg, values[i], i, values);
+      }
+    }
+  }
+
   // Replaces the specified method with the return value of funcSource.
   //
   // Note that funcSource should not BE the new method, it should be a function
@@ -431,15 +442,13 @@
   // Statically render all elements that are of this widget's class
   window.HTMLWidgets.staticRender = function() {
     var bindings = window.HTMLWidgets.widgets || [];
-    for (var i = 0; i < bindings.length; i++) {
-      var binding = bindings[i];
+    forEach(bindings, function(binding) {
       var matches = binding.find(document.documentElement);
-      for (var j = 0; j < matches.length; j++) {
-        var el = matches[j];
+      forEach(matches, function(el) {
         var sizeObj = initSizing(el, binding);
 
         if (hasClass(el, "html-widget-static-bound"))
-          continue;
+          return;
         el.className = el.className + " html-widget-static-bound";
 
         var initResult;
@@ -504,8 +513,8 @@
           }
           binding.renderValue(el, data.x, initResult);
         }
-      }
-    }
+      });
+    });
   }
 
   // Wait until after the document has loaded to render the widgets.


### PR DESCRIPTION
If there were multiple static widgets in the same document, not
all would receive resize() calls. Repro case is to create an
R Markdown ioslides presentation, and on slide 4 add one leaflet
map, and on slide 5 add another one. Only the second one would
be rendered properly. Here's an example, see slide 4:

https://rawgit.com/ldecicco-USGS/toxEval/master/samplePres.html

This was due to me using function-scoped variables inside of a
loop that created closures:

```javascript
for (var i = 0; i < bindings.length; i++) {
  var binding = bindings[i];
  var matches = binding.find(document.documentElement);
  for (var j = 0; j < matches.length; j++) {
    var el = matches[j];
    function resizeHandler() {
      // do stuff with binding and el
    }
  }
}
```

The binding and el variables are scoped to the entire function,
so all the iterations all share the same variable, and therefore
all the resizeHandler closures are bound to the same binding and
el values (the final ones).

The solution is to change the for-loops into forEach calls, since
the callback function into forEach will result in an isolated
scope being created for each iteration.