### PR TITLE
Only replace </script>, instead of all HTML tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.4.1
+Version: 0.4.2
 Date: 2015-05-17
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -129,9 +129,9 @@ widget_data <- function(x, id, ...){
   # repro for the bug this gsub fixes is to have the string "</script>" appear
   # anywhere in the data/metadata of a widget--you will get a syntax error
   # instead of a properly rendered widget.
-  tags$script(type="application/json", `data-for` = id,
-    HTML(gsub("<", "\\\\u003c", toJSON(createPayload(x))))
-  )
+  payload <- toJSON(createPayload(x))
+  payload <- gsub("</(script)>", "\\\\u003c/\\1>", payload, ignore.case = TRUE)
+  tags$script(type = "application/json", `data-for` = id, HTML(payload))
 }
 
 #' Create an HTML Widget


### PR DESCRIPTION
This PR narrows the fix in #104. If it is unnecessary to uglify all HTML tags, I'd vote not to do so. Will this work? @jcheng5 