### PR TITLE
Pass the shiny session object and output id to preRenderHook()

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -306,7 +306,7 @@ checkShinyVersion <- function(error = TRUE) {
 createPayload <- function(instance, ...){
   hook <- instance$preRenderHook
   if (is.function(hook)) {
-    instance <- if (length(list(...)) && length(formals(hook)) > 1) {
+    instance <- if (length(formals(hook)) > 1 && length(list(...))) {
       hook(instance, ...)
     } else hook(instance)
   }


### PR DESCRIPTION
This change will significantly simplify the usage of `DT::datatable(server = TRUE)`. Basically I passed two objects `shinysession` (the shiny session object) and `name` (the output id) to the hook `preRenderHook()`. I need them to register a data object in a shiny session so DataTables can send Ajax requests to the URL returned by the registration. Previously, the server-side DataTables looks like this:

``` r
shinyServer(function(input, output, session) {
  action = dataTableAjax(session, iris)
  widget = datatable(iris, server = TRUE, options = list(
    ajax = list(url = action)
  ))
  output$tbl = DT::renderDataTable(widget)
})
```

With this change, users will no longer have to worry about DataTables internals like the Ajax URL. Just `server = TRUE`, and it works.

``` r
shinyServer(function(input, output, session) {
  widget = datatable(iris, server = TRUE)
  output$tbl = DT::renderDataTable(widget)
})
```

I have taken backward compatibility into consideration: if the hook only has one argument, I will ignore the additional arguments `shinysession` and `name`.

Hopefully this is a simple enough PR that can get merged quickly. The corresponding change in DT is here: https://github.com/rstudio/DT/commit/ba899e37f0725ed89c179f753b60dc22466d54e7 I'm thinking about the CRAN release of DT, and will need a new release of htmlwidgets accordingly. Thanks!
