### PR TITLE
Increase pandoc stack size to 64MB for saveWidget

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.5
+Version: 0.5.1
 Date: 2015-06-21
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+htmlwidgets 0.5.1 (unreleased)
+-----------------------------------------------------------------------
+
+* Increase pandoc stack size to 64MB for saveWidget (often required for
+  e.g. larger embedded leaflet maps)
+
+
 htmlwidgets 0.5
 -----------------------------------------------------------------------
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -36,7 +36,8 @@ pandoc_self_contained_html <- function(input, output) {
     output = output,
     options = c(
       "--self-contained",
-      "--template", template
+      "--template", template,
+      "+RTS", "-K64m", "-RTS"
     )
   )
 


### PR DESCRIPTION
This is often required in order for widgets with large base64 payloads to render into standalone HTML (several reports of this with embedded leaflet maps have already been made).

Note that htmlwidgets includes a clone of the pandoc function from rmarkdown (so as to not have to depend on rmarkdown). I'll make the same change in rmarkdown, and look to factor those functions out of rmarkdown and into a pandoc package to eliminate the duplication.
