### PR TITLE
set pandoc stack size to 512mb (same as GHCi) and allow override

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -14,7 +14,7 @@ pandoc_available <- function(version = NULL) {
     FALSE
 }
 
-pandoc_self_contained_html <- function(input, output) {
+pandoc_self_contained_html <- function(input, output, stack_size = "512m") {
 
   # make input file path absolute
   input <- normalizePath(input)
@@ -37,7 +37,7 @@ pandoc_self_contained_html <- function(input, output) {
     options = c(
       "--self-contained",
       "--template", template,
-      "+RTS", "-K64m", "-RTS"
+      "+RTS", paste0("-K", stack_size), "-RTS"
     )
   )
 

--- a/R/savewidget.R
+++ b/R/savewidget.R
@@ -9,10 +9,13 @@
 #'   placed in an adjacent directory.
 #' @param libdir Directory to copy HTML dependencies into (defaults to
 #'   filename_files).
-#' @param background Text string giving the html background color of the widget. Defaults to white.
+#' @param stack_size Size of stack to use for pandoc conversion (defaults to
+#'   512m). Larger base64 content payloads may require larger stack sizes).
+#' @param background Text string giving the html background color of the widget.
+#'   Defaults to white.
 #'
 #' @export
-saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL, background="white") {
+saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL, background="white", stack_size = "512m") {
 
   # convert to HTML tags
   html <- toHTML(widget, standalone = TRUE)
@@ -34,7 +37,7 @@ saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL, backgr
            "https://github.com/rstudio/rmarkdown/blob/master/PANDOC.md")
     }
 
-    pandoc_self_contained_html(file, file)
+    pandoc_self_contained_html(file, file, stack_size = stack_size)
     unlink(libdir, recursive = TRUE)
   }
 

--- a/man/saveWidget.Rd
+++ b/man/saveWidget.Rd
@@ -5,7 +5,7 @@
 \title{Save a widget to an HTML file}
 \usage{
 saveWidget(widget, file, selfcontained = TRUE, libdir = NULL,
-  background = "white")
+  background = "white", stack_size = "512m")
 }
 \arguments{
 \item{widget}{Widget to save}
@@ -19,7 +19,11 @@ placed in an adjacent directory.}
 \item{libdir}{Directory to copy HTML dependencies into (defaults to
 filename_files).}
 
-\item{background}{Text string giving the html background color of the widget. Defaults to white.}
+\item{background}{Text string giving the html background color of the widget.
+  Defaults to white.}
+
+\item{stack_size}{Size of stack to use for pandoc conversion (defaults to
+512m). Larger base64 content payloads may require larger stack sizes).}
 }
 \description{
 Save a rendered widget to an HTML file (e.g. for sharing with others).


### PR DESCRIPTION
The user I put this fix in for actually had another leaflet map that blew past the 64MB (I tried 128MB and it worked fine). Note that the size of the file generated by saveWidget was only ~ 750kb so this wasn't an edge case that we shouldn't expect to see crop up again.

I did some research into GHC stack sizes and found that while the default for compiled programs was 8MB, GHCi (their interactive front-end) uses a default of 512MB. Furthermore, it sounds like this just establishes a maximum stack size rather than pre-allocating the pages:

http://stackoverflow.com/questions/20312960/non-tail-recursive-function-not-blowing-up-in-ghci-why/20313059#20313059

Given this I see no reason not to set our stack size to 512MB (as this PR does). However, at the same time I expose the knobs for users to tune it up and down. However, perhaps it's enough to just use 512MB and be done with it. 

Interested in what others think about (a) what the right default limit is; and (b) whether we should make this tunable or not.
