### PR TITLE
Increase pandoc stack size to 512 and allow override via option

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -36,8 +36,7 @@ pandoc_self_contained_html <- function(input, output) {
     output = output,
     options = c(
       "--self-contained",
-      "--template", template,
-      "+RTS", "-K64m", "-RTS"
+      "--template", template
     )
   )
 
@@ -78,6 +77,10 @@ pandoc_convert <- function(input,
 
   # additional command line options
   args <- c(args, options)
+
+  # set pandoc stack size
+  stack_size <- getOption("pandoc.stack.size", default = "512m")
+  args <- c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
 
   # build the conversion command
   command <- paste(quoted(pandoc()), paste(quoted(args), collapse = " "))


### PR DESCRIPTION
Here's another approach to same issue addressed in https://github.com/ramnathv/htmlwidgets/pull/131 (note that only one not both of these PRs should ultimately be merged).

I think I like the global option better because (a) It doesn't clutter up the calling interface of the pandoc functions; (b) It allows user control over the behavior even when developers haven't expressly exposed a knob to tune it; (c) All packages using pandoc can benefit from a single expression of user intent regarding stack usage.

I'm going to close the first PR for now and we can re-open it if folks prefer the first approach.
