### PR TITLE
add option to control copying of widget bindings

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -48,9 +48,14 @@ getDependency <- function(name, package = name){
 
   # Create a dependency that will cause the jsfile and only the jsfile (rather
   # than all of its filesystem siblings) to be copied
-  bindingDir <- tempfile("widgetbinding")
-  dir.create(bindingDir, mode = "0700")
-  file.copy(system.file(jsfile, package = package), bindingDir)
+  copyBindingDir = getOption('htmlwidgets.copybindingdir', default = TRUE)
+  if (copyBindingDir){
+    bindingDir <- tempfile("widgetbinding")
+    dir.create(bindingDir, mode = "0700")
+    file.copy(system.file(jsfile, package = package), bindingDir)
+  } else {
+    bindingDir = system.file("htmlwidgets", package = package)
+  }
 
   bindingDep <- htmlDependency(paste0(name, "-binding"), packageVersion(package),
     bindingDir,


### PR DESCRIPTION
The widget binding js files are copied over to a temporary directory. This is done so that pandoc can later pick up only the widget js file rather than all of its file system siblings. This PR allows the user to control this behavior by introducing a global option `htmlwidgets.copybindingdir`. It is set to TRUE by default so that current behavior stays unchanged. If a user sets it to FALSE, the widget binding files will not be copied over to a temporary directory and instead served directly from the package directory.