### PR TITLE
add missing semicolon in style in shinyWidgetOutput

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -249,7 +249,7 @@ shinyWidgetOutput <- function(outputId, name, width, height, package = name) {
   html <- htmltools::tagList(
     widget_html(name, package, id = outputId,
       class = paste(name, "html-widget html-widget-output"),
-      style = sprintf("width:%s; height:%s",
+      style = sprintf("width:%s; height:%s;",
         htmltools::validateCssUnit(width),
         htmltools::validateCssUnit(height)
       ), width = width, height = height


### PR DESCRIPTION
Not sure if this is best to pull to `master` or another branch, but I discovered a missing `;` in `shinyWidgetOutput` that can cause trouble when an htmlwidget has a custom html method that might also set styling.  The [line in question](https://github.com/ramnathv/htmlwidgets/blob/master/R/htmlwidgets.R#L252) reads

```
      style = sprintf("width:%s; height:%s",
```

and my change

```
      style = sprintf("width:%s; height:%s;",
```

