### PR TITLE
Fix escaping of HTML tags in JSON strings. Closes #168

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.5.1
+Version: 0.5.2
 Date: 2015-06-21
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
-htmlwidgets 0.5.1 (unreleased)
+htmlwidgets 0.5.2 (unreleased)
 -----------------------------------------------------------------------
+
+* Fix a bug where the string "</body></html>" in the widget data caused
+  `saveWidget()` to have malformed output. (#168)
 
 * Increase pandoc stack size to 512M for saveWidget (often required for
   e.g. larger embedded leaflet maps). Stack size can also be controlled

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -129,8 +129,13 @@ widget_data <- function(x, id, ...){
   # repro for the bug this gsub fixes is to have the string "</script>" appear
   # anywhere in the data/metadata of a widget--you will get a syntax error
   # instead of a properly rendered widget.
+  #
+  # Another issue is that if </body></html> appears inside a quoted string,
+  # then when pandoc coverts it with --self-contained, the escaping gets messed
+  # up. There may be other patterns that trigger this behavior, so to be safe
+  # we can replace all instances of "</" with "\\u003c/".
   payload <- toJSON(createPayload(x))
-  payload <- gsub("</(script)>", "\\\\u003c/\\1>", payload, ignore.case = TRUE)
+  payload <- gsub("</", "\\u003c/", payload, fixed = TRUE)
   tags$script(type = "application/json", `data-for` = id, HTML(payload))
 }
 


### PR DESCRIPTION
This fixes #168.

The previous code used the replacement string `\\\\u003c`, but I believe this is incorrect -- it should be `\\u003c`.