### PR TITLE
Introduce new-style instance-bound widget definitions

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -647,7 +647,7 @@
   // to rewrite all the logic in this file to accomodate both
   // types of definitions.
   function createLegacyDefinitionAdapter(defn) {
-    return {
+    var result = {
       name: defn.name,
       type: defn.type,
       initialize: function(el, width, height) {
@@ -660,6 +660,15 @@
         return instance.resize(width, height);
       }
     };
+
+    if (defn.find)
+      result.find = defn.find;
+    if (defn.renderError)
+      result.renderError = defn.renderError;
+    if (defn.clearError)
+      result.clearError = defn.clearError;
+
+    return result;
   }
 })();
 

--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -476,6 +476,7 @@
             sizeObj ? sizeObj.getWidth() : el.offsetWidth,
             sizeObj ? sizeObj.getHeight() : el.offsetHeight
           );
+          elementData(el, "init_result", initResult);
         }
 
         if (binding.resize) {
@@ -640,6 +641,57 @@
         }
       }
     }
+  };
+
+  // Retrieve the HTMLWidget instance (i.e. the return value of an
+  // HTMLWidget binding's initialize() or factory() function)
+  // associated with an element, or null if none.
+  window.HTMLWidgets.getInstance = function(el) {
+    return elementData(el, "init_result");
+  };
+
+  // Finds the first element in the scope that matches the selector,
+  // and returns the HTMLWidget instance (i.e. the return value of
+  // an HTMLWidget binding's initialize() or factory() function)
+  // associated with that element, if any. If no element matches the
+  // selector, or the first matching element has no HTMLWidget
+  // instance associated with it, then null is returned.
+  //
+  // The scope argument is optional, and defaults to window.document.
+  window.HTMLWidgets.find = function(scope, selector) {
+    if (arguments.length == 1) {
+      selector = scope;
+      scope = document;
+    }
+
+    var el = scope.querySelector(selector);
+    if (el === null) {
+      return null;
+    } else {
+      return window.HTMLWidgets.getInstance(el);
+    }
+  };
+
+  // Finds all elements in the scope that match the selector, and
+  // returns the HTMLWidget instances (i.e. the return values of
+  // an HTMLWidget binding's initialize() or factory() function)
+  // associated with the elements, in an array. If elements that
+  // match the selector don't have an associated HTMLWidget
+  // instance, the returned array will contain nulls.
+  //
+  // The scope argument is optional, and defaults to window.document.
+  window.HTMLWidgets.findAll = function(scope, selector) {
+    if (arguments.length == 1) {
+      selector = scope;
+      scope = document;
+    }
+
+    var nodes = scope.querySelectorAll(selector);
+    var results = [];
+    for (var i = 0; i < nodes.length; i++) {
+      results.push(window.HTMLWidgets.getInstance(nodes[i]));
+    }
+    return results;
   };
 
   // Takes a new-style instance-bound definition, and returns an


### PR DESCRIPTION
This is part 1 of letting users add arbitrary JS to orchestrate htmlwidget components. Up until now we have mostly focused on inserting a visualization into a page and being done--the only times any code from outside the visualization interacts with that visualization again, is if 1) the container is resized, then we call resize(); and 2) in Shiny contexts, new data can be provided and renderValue() gets called again in that case.

What I would like to allow going forward is arbitrary interaction with htmlwidget components from code outside of the component. You should be able to have your widget expose whatever methods you want, and it should be easy to call those components from JavaScript running elsewhere in the page.

For this to happen we need two things to happen.

1. It needs to be easy and natural for htmlwidget authors to add custom methods that can be invoked on a widget instance. This was not easy nor natural in the past, because the object that you pass into `HTMLWidgets.widget()` was a single object that was responsible for all widget instances of that type. (This also led to an awkward programming style in general.) This PR changes this to one-object-per-widget-instance.
2. You need to be able to easily specify an ID for a widget, and then use that ID from JavaScript to access the widget instance (like `HTMLWidgets.get(id)`). This will be introduced in a separate PR.

Once both items are in place you'll be able to do something like this (assuming appropriate support in the widgets themselves:

```r
widgetGridPage(
  widget1(id = "one", data = iris, ...),
  widget2(id = "two", data = iris, ...),
  tags$script("
    HTMLWidgets.get('one').on('bounds-changed', function(e) {
      HTMLWidgets.get('two').setBounds(e.value);
    });
  ")
)
```

Take a look at the difference between these two otherwise-identical bindings to see the contrast between the existing class-bound definitions and the new instance-bound definitions.

[Class-bound](https://github.com/jcheng5/d3scatter/blob/94e512f6edc15a4ac122e61136e1d40ca6ff8a6e/inst/htmlwidgets/d3scatter.js)
[Instance-bound](https://github.com/jcheng5/d3scatter/blob/470c571f48e6fe895bc2af4bc3cc159d8df63cbe/inst/htmlwidgets/d3scatter.js)

This particular instance-bound example doesn't do anything besides support `renderValue` and `resize`, but you could imagine any number of properties and methods added to that object.