### PR TITLE
Move templates to files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.5.2
+Version: 0.5.3
 Date: 2015-06-21
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),

--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -31,58 +31,9 @@ scaffoldWidget <- function(name, bowerPkg = NULL, edit = interactive()){
 }
 
 addWidgetConstructor <- function(name, package, edit){
-  tpl <- "#' <Add Title>
-#'
-#' <Add Description>
-#'
-#' @import htmlwidgets
-#'
-#' @export
-%s <- function(message, width = NULL, height = NULL) {
-
-  # forward options using x
-  x = list(
-    message = message
-  )
-
-  # create widget
-  htmlwidgets::createWidget(
-    name = '%s',
-    x,
-    width = width,
-    height = height,
-    package = '%s'
-  )
-}
-
-#' Shiny bindings for %s
-#'
-#' Output and render functions for using %s within Shiny
-#' applications and interactive Rmd documents.
-#'
-#' @param outputId output variable to read from
-#' @param width,height Must be a valid CSS unit (like \\code{'100\\%%'},
-#'   \\code{'400px'}, \\code{'auto'}) or a number, which will be coerced to a
-#'   string and have \\code{'px'} appended.
-#' @param expr An expression that generates a %s
-#' @param env The environment in which to evaluate \\code{expr}.
-#' @param quoted Is \\code{expr} a quoted expression (with \\code{quote()})? This
-#'   is useful if you want to save an expression in a variable.
-#'
-#' @name %s-shiny
-#'
-#' @export
-%sOutput <- function(outputId, width = '100%%', height = '400px'){
-  shinyWidgetOutput(outputId, '%s', width, height, package = '%s')
-}
-
-#' @rdname %s-shiny
-#' @export
-render%s <- function(expr, env = parent.frame(), quoted = FALSE) {
-  if (!quoted) { expr <- substitute(expr) } # force quoted
-  shinyRenderWidget(expr, %sOutput, env, quoted = TRUE)
-}
-"
+  tpl <- paste(readLines(
+    system.file('templates/widget_r.txt', package = 'htmlwidgets')
+  ), collapse = "\n")
 
   capName = function(name){
     paste0(toupper(substring(name, 1, 1)), substring(name, 2))
@@ -128,32 +79,10 @@ addWidgetYAML <- function(name, bowerPkg, edit){
 }
 
 addWidgetJS <- function(name, edit){
-  tpl <- "HTMLWidgets.widget({
+  tpl <- paste(readLines(
+    system.file('templates/widget_js_new.txt', package = 'htmlwidgets')
+  ), collapse = "\n")
 
-  name: '%s',
-
-  type: 'output',
-
-  initialize: function(el, width, height) {
-
-    return {
-      // TODO: add instance fields as required
-    }
-
-  },
-
-  renderValue: function(el, x, instance) {
-
-    el.innerText = x.message;
-
-  },
-
-  resize: function(el, width, height, instance) {
-
-  }
-
-});
-"
   if (!file.exists(file_ <- sprintf('inst/htmlwidgets/%s.js', name))){
     cat(sprintf(tpl, name), file = file_)
     message('Created boilerplate for widget javascript bindings at ',

--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -79,8 +79,13 @@ addWidgetYAML <- function(name, bowerPkg, edit){
 }
 
 addWidgetJS <- function(name, edit){
+  if (packageVersion('htmlwidgets') <= '0.5.2'){
+    tplFile = 'templates/widget_js.txt'
+  } else {
+    tplFile = 'templates/widget_js_new.txt'
+  }
   tpl <- paste(readLines(
-    system.file('templates/widget_js_new.txt', package = 'htmlwidgets')
+    system.file(tplFile, package = 'htmlwidgets')
   ), collapse = "\n")
 
   if (!file.exists(file_ <- sprintf('inst/htmlwidgets/%s.js', name))){

--- a/inst/templates/widget_js.txt
+++ b/inst/templates/widget_js.txt
@@ -1,0 +1,25 @@
+HTMLWidgets.widget({
+
+  name: '%s',
+
+  type: 'output',
+
+  initialize: function(el, width, height) {
+
+    return {
+      // TODO: add instance fields as required
+    }
+
+  },
+
+  renderValue: function(el, x, instance) {
+
+    el.innerText = x.message;
+
+  },
+
+  resize: function(el, width, height, instance) {
+
+  }
+
+});

--- a/inst/templates/widget_js_new.txt
+++ b/inst/templates/widget_js_new.txt
@@ -1,0 +1,19 @@
+HTMLWidgets.widget({
+
+  name: '%s',
+
+  type: 'output',
+
+  factory: function(el, width, height) {
+
+    return {
+      renderValue: function(x) {
+        el.innerText = x.message
+      },
+      resize: function(width, height) {
+
+      }
+    };
+
+  }
+});

--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -5,7 +5,7 @@
 #' @import htmlwidgets
 #'
 #' @export
-%s <- function(message, width = NULL, height = NULL) {
+%s <- function(message, width = NULL, height = NULL, elementId = NULL) {
 
   # forward options using x
   x = list(
@@ -15,10 +15,11 @@
   # create widget
   htmlwidgets::createWidget(
     name = '%s',
-    x,
+    x = x,
     width = width,
     height = height,
-    package = '%s'
+    package = '%s',
+    elementId = elementId
   )
 }
 

--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -1,0 +1,51 @@
+#' <Add Title...>
+#'
+#' <Add Description>
+#'
+#' @import htmlwidgets
+#'
+#' @export
+%s <- function(message, width = NULL, height = NULL) {
+
+  # forward options using x
+  x = list(
+    message = message
+  )
+
+  # create widget
+  htmlwidgets::createWidget(
+    name = '%s',
+    x,
+    width = width,
+    height = height,
+    package = '%s'
+  )
+}
+
+#' Shiny bindings for %s
+#'
+#' Output and render functions for using %s within Shiny
+#' applications and interactive Rmd documents.
+#'
+#' @param outputId output variable to read from
+#' @param width,height Must be a valid CSS unit (like \\code{'100\\%%'},
+#'   \\code{'400px'}, \\code{'auto'}) or a number, which will be coerced to a
+#'   string and have \\code{'px'} appended.
+#' @param expr An expression that generates a %s
+#' @param env The environment in which to evaluate \\code{expr}.
+#' @param quoted Is \\code{expr} a quoted expression (with \\code{quote()})? This
+#'   is useful if you want to save an expression in a variable.
+#'
+#' @name %s-shiny
+#'
+#' @export
+%sOutput <- function(outputId, width = '100%%', height = '400px'){
+  shinyWidgetOutput(outputId, '%s', width, height, package = '%s')
+}
+
+#' @rdname %s-shiny
+#' @export
+render%s <- function(expr, env = parent.frame(), quoted = FALSE) {
+  if (!quoted) { expr <- substitute(expr) } # force quoted
+  shinyRenderWidget(expr, %sOutput, env, quoted = TRUE)
+}


### PR DESCRIPTION
This PR does a couple of things:

1. Moves scaffold code into templates, so that it doesn't trip later versions of `roxygen2`.
2. Adds scaffold template for the new instance based specification of widgets.
3. Bumps version number.

This PR only touches scaffolding code. So, we only need to confirm that `htmlwidgets::scaffoldWidget` works as before. I have tested it locally and everything seems to be working well. But it would be good if a few of you could independently test it and confirm before we merge. @timelyportfolio @jjallaire @jcheng5 @yihui 