### PR TITLE
Avoid copying the js binding to a temp dir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: A framework for creating HTML widgets that render in various
 License: MIT + file LICENSE
 VignetteBuilder: knitr
 Imports:
-    htmltools (>= 0.3.3),
+    htmltools (>= 0.3),
     jsonlite (>= 0.9.16),
     yaml
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: A framework for creating HTML widgets that render in various
 License: MIT + file LICENSE
 VignetteBuilder: knitr
 Imports:
-    htmltools (>= 0.2.6),
+    htmltools (>= 0.3.2),
     jsonlite (>= 0.9.16),
     yaml
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: A framework for creating HTML widgets that render in various
 License: MIT + file LICENSE
 VignetteBuilder: knitr
 Imports:
-    htmltools (>= 0.3.2),
+    htmltools (>= 0.3.3),
     jsonlite (>= 0.9.16),
     yaml
 Suggests:

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,15 +46,16 @@ getDependency <- function(name, package = name){
     do.call(htmlDependency, l)
   })
 
+  bindingDir <- system.file("htmlwidgets", package = package)
+  argsDep <- NULL
+  copyBindingDir <- getOption('htmlwidgets.copybindingdir', TRUE)
   # TODO: remove this trick when htmltools >= 0.3.3 is on CRAN
-  if (packageVersion('htmltools') < '0.3.3') {
-    bindingDir <- tempfile("widgetbinding")
-    dir.create(bindingDir, mode = "0700")
-    file.copy(system.file(jsfile, package = package), bindingDir)
-    argsDep <- NULL
-  } else {
-    bindingDir <- system.file("htmlwidgets", package = package)
-    argsDep <- list(all_files = FALSE)
+  if (copyBindingDir) {
+    if (packageVersion('htmltools') < '0.3.3') {
+      bindingDir <- tempfile("widgetbinding")
+      dir.create(bindingDir, mode = "0700")
+      file.copy(system.file(jsfile, package = package), bindingDir)
+    } else argsDep <- list(all_files = FALSE)
   }
   bindingDep <- do.call(htmlDependency, c(list(
     paste0(name, "-binding"), packageVersion(package),

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,11 +54,10 @@ getDependency <- function(name, package = name){
   } else {
     bindingDir <- system.file("htmlwidgets", package = package)
   }
-  bindingDep <- htmlDependency(paste0(name, "-binding"), packageVersion(package),
-    bindingDir,
-    script = basename(jsfile)
-  )
-  if (packageVersion('htmltools' >= '0.3.3')) bindingDep$all_files <- FALSE
+  bindingDep <- do.call(htmlDependency, c(list(
+    paste0(name, "-binding"), packageVersion(package),
+    bindingDir, script = basename(jsfile)
+  ), if (packageVersion('htmltools' >= '0.3.3')) list(all_files = FALSE)))
 
   c(
     list(htmlDependency("htmlwidgets", packageVersion("htmlwidgets"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,20 +46,10 @@ getDependency <- function(name, package = name){
     do.call(htmlDependency, l)
   })
 
-  # Create a dependency that will cause the jsfile and only the jsfile (rather
-  # than all of its filesystem siblings) to be copied
-  copyBindingDir = getOption('htmlwidgets.copybindingdir', default = TRUE)
-  if (copyBindingDir){
-    bindingDir <- tempfile("widgetbinding")
-    dir.create(bindingDir, mode = "0700")
-    file.copy(system.file(jsfile, package = package), bindingDir)
-  } else {
-    bindingDir = system.file("htmlwidgets", package = package)
-  }
-
   bindingDep <- htmlDependency(paste0(name, "-binding"), packageVersion(package),
-    bindingDir,
-    script = basename(jsfile)
+    system.file("htmlwidgets", package = package),
+    script = basename(jsfile),
+    all_files = !getOption('htmlwidgets.copybindingdir', TRUE)
   )
 
   c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,8 +48,7 @@ getDependency <- function(name, package = name){
 
   bindingDep <- htmlDependency(paste0(name, "-binding"), packageVersion(package),
     system.file("htmlwidgets", package = package),
-    script = basename(jsfile),
-    all_files = !getOption('htmlwidgets.copybindingdir', TRUE)
+    script = basename(jsfile), all_files = FALSE
   )
 
   c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,10 +46,19 @@ getDependency <- function(name, package = name){
     do.call(htmlDependency, l)
   })
 
+  # TODO: remove this trick when htmltools >= 0.3.3 is on CRAN
+  if (packageVersion('htmltools') < '0.3.3') {
+    bindingDir <- tempfile("widgetbinding")
+    dir.create(bindingDir, mode = "0700")
+    file.copy(system.file(jsfile, package = package), bindingDir)
+  } else {
+    bindingDir <- system.file("htmlwidgets", package = package)
+  }
   bindingDep <- htmlDependency(paste0(name, "-binding"), packageVersion(package),
-    system.file("htmlwidgets", package = package),
-    script = basename(jsfile), all_files = FALSE
+    bindingDir,
+    script = basename(jsfile)
   )
+  if (packageVersion('htmltools' >= '0.3.3')) bindingDep$all_files <- FALSE
 
   c(
     list(htmlDependency("htmlwidgets", packageVersion("htmlwidgets"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,13 +51,15 @@ getDependency <- function(name, package = name){
     bindingDir <- tempfile("widgetbinding")
     dir.create(bindingDir, mode = "0700")
     file.copy(system.file(jsfile, package = package), bindingDir)
+    argsDep <- NULL
   } else {
     bindingDir <- system.file("htmlwidgets", package = package)
+    argsDep <- list(all_files = FALSE)
   }
   bindingDep <- do.call(htmlDependency, c(list(
     paste0(name, "-binding"), packageVersion(package),
     bindingDir, script = basename(jsfile)
-  ), if (packageVersion('htmltools' >= '0.3.3')) list(all_files = FALSE)))
+  ), argsDep))
 
   c(
     list(htmlDependency("htmlwidgets", packageVersion("htmlwidgets"),


### PR DESCRIPTION
Because otherwise it is impossible to cache code chunks that involve HTML widgets: the temp dir path changes between R sessions and gets deleted every time R quits, so the dependency object will not be reusable for the next R session

Note this PR relies on https://github.com/rstudio/htmltools/pull/48