### PR TITLE
Shown/hidden events not subscribed to properly for Bootstrap 3

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -524,8 +524,8 @@
           // call resize handlers for Shiny outputs, not for static
           // widgets, so we do it ourselves.
           if (window.jQuery) {
-            window.jQuery(document).on("shown", resizeHandler);
-            window.jQuery(document).on("hidden", resizeHandler);
+            window.jQuery(document).on("shown.htmlwidgets shown.bs.tab.htmlwidgets", resizeHandler);
+            window.jQuery(document).on("hidden.htmlwidgets hidden.bs.tab.htmlwidgets", resizeHandler);
           }
 
           // This is needed for the specific case of ioslides, which


### PR DESCRIPTION
This should fix the common issue of htmlwidgets not working with some Shiny tab layouts and other Bootstrap 3 based showing/hiding mechanisms.

The "shown" and "hidden" events work with Bootstrap 2, but not Bootstrap 3, unfortunately. We should be listening for both. I also added the `.htmlwidgets` namespace to the end. It will still subscribe to `shown` and `shown.bs.tab`, see the event namespaces docs here: http://api.jquery.com/on/