### PR TITLE
add html-widget class to static widgets

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -156,7 +156,7 @@ toHTML <- function(x, standalone = FALSE, knitrOptions = NULL) {
           package = attr(x, "package"),
           id = id,
           style = style,
-          class = class(x)[1],
+          class = paste(class(x)[1], "html-widget"),
           width = sizeInfo$width,
           height = sizeInfo$height
         ),


### PR DESCRIPTION
This PR adds the `html-widget` class to static widgets (we already do this for shiny widgets here: https://github.com/ramnathv/htmlwidgets/blob/master/R/htmlwidgets.R#L338). 