### PR TITLE
Move new `inline` param, for back-compat

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -302,9 +302,9 @@ createWidget <- function(name,
 #' @param width,height Must be a valid CSS unit (like \code{"100\%"},
 #'   \code{"400px"}, \code{"auto"}) or a number, which will be coerced to a
 #'   string and have \code{"px"} appended.
+#' @param package Package containing widget (defaults to \code{name})
 #' @param inline use an inline (\code{span()}) or block container (\code{div()})
 #' for the output
-#' @param package Package containing widget (defaults to \code{name})
 #' @param outputFunction Shiny output function corresponding to this render
 #'   function.
 #' @param expr An expression that generates an HTML widget
@@ -333,8 +333,8 @@ createWidget <- function(name,
 #' @name htmlwidgets-shiny
 #'
 #' @export
-shinyWidgetOutput <- function(outputId, name, width, height, inline = FALSE,
-                              package = name) {
+shinyWidgetOutput <- function(outputId, name, width, height, package = name,
+                              inline = FALSE) {
 
   checkShinyVersion()
   # generate html

--- a/man/htmlwidgets-shiny.Rd
+++ b/man/htmlwidgets-shiny.Rd
@@ -6,8 +6,8 @@
 \alias{shinyWidgetOutput}
 \title{Shiny bindings for HTML widgets}
 \usage{
-shinyWidgetOutput(outputId, name, width, height, inline = FALSE,
-  package = name)
+shinyWidgetOutput(outputId, name, width, height, package = name,
+  inline = FALSE)
 
 shinyRenderWidget(expr, outputFunction, env, quoted)
 }
@@ -20,10 +20,10 @@ shinyRenderWidget(expr, outputFunction, env, quoted)
 \code{"400px"}, \code{"auto"}) or a number, which will be coerced to a
 string and have \code{"px"} appended.}
 
+\item{package}{Package containing widget (defaults to \code{name})}
+
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
-
-\item{package}{Package containing widget (defaults to \code{name})}
 
 \item{expr}{An expression that generates an HTML widget}
 


### PR DESCRIPTION
The introduction of the new `inline` parameter broke any
code that assumed the 5th argument was `package`. This
isn't the case for scaffold-generated widgets, but at
least the leaflet package made this assumption.