### PR TITLE
call widget.resize when slides are shown

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -588,20 +588,13 @@
               "hidden.htmlwidgets hidden.bs.tab.htmlwidgets hidden.bs.collapse.htmlwidgets",
               resizeHandler
             );
-          }
 
-          // This is needed for the specific case of ioslides, which
-          // flips slides between display:none and display:block.
-          // Ideally we would not have to have ioslide-specific code
-          // here, but rather have ioslides raise a generic event,
-          // but the rmarkdown package just went to CRAN so the
-          // window to getting that fixed may be long.
-          if (window.addEventListener) {
-            // It's OK to limit this to window.addEventListener
-            // browsers because ioslides itself only supports
-            // such browsers.
-            on(document, "slideenter", resizeHandler);
-            on(document, "slideleave", resizeHandler);
+            // subscribe to custom shown event fired by ioslides and reveal.js (and
+            // perhaps other slide frameworks). This is necessary because some widgets
+            // (e.g. dygraphs) which start out as display:none have height == 0 and
+            // width == 0 and this doesn't change when it becomes visible
+            window.jQuery(el).closest('slide').on('shown', resizeHandler);
+            window.jQuery(el).closest('section.slide').on('shown', resizeHandler);
           }
         }
 


### PR DESCRIPTION
This PR hoists a workaround that I have in dygraphs into the core htmlwidgets. Here is the original code in dygraphs:

https://github.com/rstudio/dygraphs/blob/master/inst/htmlwidgets/dygraphs.js#L131-L144

The issue is that for dygraphs when they start out as display:none (which is the case in ioslides and revealjs among perhaps others) their width and height is 0. This means that when the slide they are hosted on is shown they appear invisible.

Most widgets don't have this problem, but at least one developed by @bwlewis does and it must also also affect others. @bwlewis Could you confirm that this resolves the problems you have been seeing?