### PR TITLE
Add elementId to R template function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.6.1
-Date: 2016-02-25
+Version: 0.6.2
+Date: 2016-06-15
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),

--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -5,7 +5,7 @@
 #' @import htmlwidgets
 #'
 #' @export
-%s <- function(message, width = NULL, height = NULL) {
+%s <- function(message, width = NULL, height = NULL, elementId = NULL) {
 
   # forward options using x
   x = list(
@@ -18,7 +18,8 @@
     x,
     width = width,
     height = height,
-    package = '%s'
+    package = '%s',
+    elementId = elementId
   )
 }
 


### PR DESCRIPTION
Regarding #208, add `elementId = NULL` to the `R` template function for `scaffoldWidget`.