### PR TITLE
Ensure that scaffoldWidget opens files correctly within RStudio

### DIFF
--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -48,7 +48,7 @@ addWidgetConstructor <- function(name, package, edit){
   } else {
     message(file_, " already exists")
   }
-  if (edit) file.edit(file_)
+  if (edit) fileEdit(file_)
 }
 
 addWidgetYAML <- function(name, bowerPkg, edit){
@@ -75,7 +75,7 @@ addWidgetYAML <- function(name, bowerPkg, edit){
   } else {
     message(file_, " already exists")
   }
-  if (edit) file.edit(file_)
+  if (edit) fileEdit(file_)
 }
 
 addWidgetJS <- function(name, edit){
@@ -91,7 +91,7 @@ addWidgetJS <- function(name, edit){
   } else {
     message(file_, " already exists")
   }
-  if (edit) file.edit(file_)
+  if (edit) fileEdit(file_)
 }
 
 # Install bower package to inst/htmlwidgets/lib
@@ -183,3 +183,11 @@ getMinified <- function(x, name, src = 'inst/htmlwidgets/lib'){
     }
   })
 }
+
+# invoke file.edit in a way that will bind to the RStudio editor
+# when running inside RStudio
+fileEdit <- function(file) {
+  fileEditFunc <- eval(parse(text = "file.edit"), envir = globalenv())
+  fileEditFunc(file)
+}
+

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,6 +3,8 @@ htmlwidgets 0.7 (unreleased)
 
 * Pass knitr options to saveWidget
 
+* Ensure that scaffoldWidget opens files correctly within RStudio
+
 * The resize handler also works for the JavaScript events `shown.bs.collapse`
   and `hidden.bs.collapse` now so that widgets inside the Bootstrap collapse
   class can be displayed


### PR DESCRIPTION
RStudio overrides the `utils::file.edit` function but only when invoked unqualified within the global environment. This PR invokes file.edit in a way that will result in correct binding to the rstudio implementation when running within RStudio.

We could improve this by importing the rstudioapi package and calling the RStudio API directly, however I that's a bit more heavyweight and I don't think warranted. Note that the call to `file.edit` will fail if `utils` isn't attached to the search path but I think this will be exceptionally rare.
