### PR TITLE
pass along "style" param from htmlwidgets html to custom html

### DIFF
--- a/vignettes/develop_advanced.Rmd
+++ b/vignettes/develop_advanced.Rmd
@@ -178,7 +178,7 @@ Typically the HTML "housing" for a widget is just a `<div>` element, and this is
 
 ```r
 sparkline_html <- function(id, style, class, ...){
-  tags$span(id = id, class = class)
+  tags$span(id = id, class = class, style = style)
 }
 ```
 


### PR DESCRIPTION
I think the "style" param is necessary in order to have non-default width/height eg. `fooWidget(width = "50%")` without passing along the style, the width won't actually be 50%.

And I'm wondering if we need to use the `...` arguments at all?  Or is it always safe to ignore them?
