### PR TITLE
Fix #236: onRender doesn't work with Shiny

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 0.7
+Version: 0.8
 Date: 2016-08-01
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+htmlwidgets 0.8 (unreleased)
+-----------------------------------------------------------------------
+
+* `onRender` hooks were firing too early when used in Shiny apps.
+
+
 htmlwidgets 0.7
 -----------------------------------------------------------------------
 

--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -511,10 +511,10 @@
               el.offsetHeight);
             elementData(el, "init_result", result);
           }
-          evalAndRun(data.jsHooks.render, elementData(el, "init_result"), [el, data.x]);
         }
         Shiny.renderDependencies(data.deps);
         bindingDef.renderValue(el, data.x, elementData(el, "init_result"));
+        evalAndRun(data.jsHooks.render, elementData(el, "init_result"), [el, data.x]);
       };
 
       // Only override resize if bindingDef implements it


### PR DESCRIPTION
The `onRender` hook was being called after initialize, not after render. My bad!

cc @daattali @bhaskarvk
