### PR TITLE
Fix #238: sync with shiny:::toJSON

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,13 @@
-# Copied from shiny 0.11.1.9003
+# Copied from shiny 0.14.2
 toJSON2 <- function(
   x, ...,  dataframe = "columns", null = "null", na = "null", auto_unbox = TRUE,
   digits = getOption("shiny.json.digits", 16), use_signif = TRUE, force = TRUE,
-  POSIXt = "ISO8601", UTC = TRUE, rownames = FALSE, keep_vec_names = TRUE
+  POSIXt = "ISO8601", UTC = TRUE, rownames = FALSE, keep_vec_names = TRUE,
+  strict_atomic = TRUE
 ) {
+  if (strict_atomic) x <- I(x)
   jsonlite::toJSON(
-    I(x), dataframe = dataframe, null = null, na = na, auto_unbox = auto_unbox,
+    x, dataframe = dataframe, null = null, na = na, auto_unbox = auto_unbox,
     digits = digits, use_signif = use_signif, force = force, POSIXt = POSIXt,
     UTC = UTC, rownames = rownames, keep_vec_names = keep_vec_names,
     json_verbatim = TRUE, ...


### PR DESCRIPTION
Make sure htmlwidgets and shiny use the same JSON serializer.