### PR TITLE
Move Shiny dependency rendering to be earlier

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -489,6 +489,7 @@
       // supported natively by Shiny at the time of this writing.
 
       shinyBinding.renderValue = function(el, data) {
+        Shiny.renderDependencies(data.deps);
         // Resolve strings marked as javascript literals to objects
         if (!(data.evals instanceof Array)) data.evals = [data.evals];
         for (var i = 0; data.evals && i < data.evals.length; i++) {
@@ -512,7 +513,6 @@
             elementData(el, "init_result", result);
           }
         }
-        Shiny.renderDependencies(data.deps);
         bindingDef.renderValue(el, data.x, elementData(el, "init_result"));
         evalAndRun(data.jsHooks.render, elementData(el, "init_result"), [el, data.x]);
       };


### PR DESCRIPTION
The previous ordering caused errors when a widget's JS binding's factory
method (or initialize method, for legacy-style bindings) depends on a
dynamic dependency.

You might wonder why a dependency that's used in the intitialize method
would be dynamic and not static. For my case, it's Crosstalk, which
isn't available as a static dependency; you use crosstalk::crosstalkLibs
from R to attach the deps. It would be nice if there was a way to
express this in the widget YAML, you could just point to an R
package::function() or package::variable (though I suspect some hacks
may be needed to get around R CMD check, which wants all Imports to be
used I think?).