### PR TITLE
Avoid setting .Random.seed to NULL

### DIFF
--- a/R/widgetid.R
+++ b/R/widgetid.R
@@ -33,7 +33,10 @@ createWidgetId <- function(bytes = 10) {
     # Change our own seed to match the current seed
     .globals$idSeed <- .GlobalEnv$.Random.seed
     # Restore the system seed--we were never here
-    .GlobalEnv$.Random.seed <- sysSeed
+    if(!is.null(sysSeed))
+      .GlobalEnv$.Random.seed <- sysSeed
+    else
+      rm(".Random.seed", envir = .GlobalEnv)
   })
 
   paste(


### PR DESCRIPTION
 - Related to Issue [#980](https://github.com/rstudio/rmarkdown/issues/980) for the [rmarkdown](https://github.com/rstudio/rmarkdown) package, `htmlwidgets::createWidgetId()` can cause `.Random.seed` to be set to `NULL`, leading to an odd warning

       '.Random.seed' is not an integer vector but of type 'NULL', so ignored

 - Need to apply to `createWidgetId` the same change that was made to `setWidgetIdSeed` in [commit 7454758](https://github.com/ramnathv/htmlwidgets/commit/7454758) from @kevinushey.