### PR TITLE
Don't call `structure(NULL, *)`, as this gives a warning in R 3.4.0.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -141,6 +141,9 @@ JS <- function(...) {
 #   JavaScript are to be identified
 # @author Yihui Xie
 JSEvals <- function(list) {
+  # the `%||% list()` part is necessary as of R 3.4.0 (April 2017) -- if `evals`
+  # is NULL then `I(evals)` results in a warning in R 3.4.0. This is circumvented
+  # if we let `evals` be equal to `list()` in those cases
   evals <- names(which(unlist(shouldEval(list)))) %||% list()
   I(evals)  # need I() to prevent toJSON() from converting it to scalar
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,7 +141,7 @@ JS <- function(...) {
 #   JavaScript are to be identified
 # @author Yihui Xie
 JSEvals <- function(list) {
-  evals <- names(which(unlist(shouldEval(list))))
+  evals <- names(which(unlist(shouldEval(list)))) %||% list()
   I(evals)  # need I() to prevent toJSON() from converting it to scalar
 }
 


### PR DESCRIPTION
This can be fixed by having the underlying object default to `list()` if it was NULL. Fixes #269