### PR TITLE
Don't fetch widget dependencies if no yaml file exists

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -48,18 +48,16 @@ getDependency <- function(name, package = name) {
     src = system.file("www", package = "htmlwidgets"),
     script = "htmlwidgets.js"
   )
-  
-  config <- sprintf("htmlwidgets/%s.yaml", name)
-  jsfile <- sprintf("htmlwidgets/%s.js", name)
+
+  config <- system.file(sprintf("htmlwidgets/%s.yaml", name), package = package)
+  jsfile <- system.file(sprintf("htmlwidgets/%s.js", name), package = package)
 
   # do less magic if no yaml file exists
-  if (!file.exists(config)) {
+  if (identical(config, "")) {
     return(list(htmlWidgetDep))
   }
-  
-  config <- yaml::yaml.load_file(
-    system.file(config, package = package)
-  )
+
+  config <- yaml::yaml.load_file(config)
   widgetDep <- lapply(config$dependencies, function(l){
     l$src = system.file(l$src, package = package)
     do.call(htmlDependency, l)
@@ -73,7 +71,7 @@ getDependency <- function(name, package = name) {
     if (packageVersion('htmltools') < '0.3.3') {
       bindingDir <- tempfile("widgetbinding")
       dir.create(bindingDir, mode = "0700")
-      file.copy(system.file(jsfile, package = package), bindingDir)
+      file.copy(jsfile, bindingDir)
     } else argsDep <- list(all_files = FALSE)
   }
   bindingDep <- do.call(htmlDependency, c(list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,7 +52,10 @@ getDependency <- function(name, package = name) {
   config <- system.file(sprintf("htmlwidgets/%s.yaml", name), package = package)
   jsfile <- system.file(sprintf("htmlwidgets/%s.js", name), package = package)
 
-  # do less magic if no yaml file exists
+  # htmlwidget authors may need to place dependencies *before* the binding
+  # (i.e., jsfile) at print time. So, if no yaml exists, we just include the
+  # htmlwidgets.js dependency and leave it to the author to declare their
+  # binding dependency inside htmlwidget::createWidget()
   if (identical(config, "")) {
     return(list(htmlWidgetDep))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,11 +41,23 @@ toJSON <- function(x) {
 #' @param name name of the widget.
 #' @param package name of the package, defaults to the widget name.
 #' @export
-getDependency <- function(name, package = name){
-  config = sprintf("htmlwidgets/%s.yaml", name)
-  jsfile = sprintf("htmlwidgets/%s.js", name)
+getDependency <- function(name, package = name) {
+  htmlWidgetDep <- htmlDependency(
+    "htmlwidgets", 
+    packageVersion("htmlwidgets"),
+    src = system.file("www", package = "htmlwidgets"),
+    script = "htmlwidgets.js"
+  )
+  
+  config <- sprintf("htmlwidgets/%s.yaml", name)
+  jsfile <- sprintf("htmlwidgets/%s.js", name)
 
-  config = yaml::yaml.load_file(
+  # do less magic if no yaml file exists
+  if (!file.exists(config)) {
+    return(list(htmlWidgetDep))
+  }
+  
+  config <- yaml::yaml.load_file(
     system.file(config, package = package)
   )
   widgetDep <- lapply(config$dependencies, function(l){
@@ -70,10 +82,7 @@ getDependency <- function(name, package = name){
   ), argsDep))
 
   c(
-    list(htmlDependency("htmlwidgets", packageVersion("htmlwidgets"),
-      src = system.file("www", package="htmlwidgets"),
-      script = "htmlwidgets.js"
-    )),
+    list(htmlWidgetDep),
     widgetDep,
     list(bindingDep)
   )


### PR DESCRIPTION
As @ramnathv points out in https://github.com/ramnathv/htmlwidgets/pull/259#issuecomment-305044861, this makes `getDependency()` only return the htmlwidgets.js dependency if no yaml config file exists.

This should fix #179 and also makes #259 obsolete

