### PR TITLE
More resilient pandoc self-contained mechanism

### DIFF
--- a/R/savewidget.R
+++ b/R/savewidget.R
@@ -11,10 +11,12 @@
 #'   filename_files).
 #' @param background Text string giving the html background color of the widget.
 #'   Defaults to white.
+#' @param title Text to use as the title of the generated page.
 #' @param knitrOptions A list of \pkg{knitr} chunk options.
 #' @export
 saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL,
-                       background = "white", knitrOptions = list()) {
+                       background = "white", title = class(widget)[[1]],
+                       knitrOptions = list()) {
 
   # convert to HTML tags
   html <- toHTML(widget, standalone = TRUE, knitrOptions = knitrOptions)
@@ -25,8 +27,10 @@ saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL,
       sep = "")
   }
 
-  # save the file
-  htmltools::save_html(html, file = file, libdir = libdir, background=background)
+  # Save the file
+  # Include a title; pandoc 2.0 complains if you don't have one
+  pandoc_save_markdown(html, file = file, libdir = libdir,
+    background = background, title = title)
 
   # make it self-contained if requested
   if (selfcontained) {


### PR DESCRIPTION
Fixes two pandoc 2.0 issues with `saveWidget(selfcontained=TRUE)`:

1. The `[WARNING] This document format requires a nonempty <title> element` message from #289 
2. The `<!DOCTYPE html>` showing up as a text string in the browser (though often hidden because many htmlwidgets completely fill the page)

I tested with pandoc 2.0.2 and 1.19.2.1, both on Linux. They both seem to work fine with the examples I tried. However, one difference I noticed was that JavaScript dependencies are completely data URI/base64 encoded in 1.19.2.1, but inlined as cleartext in 2.0.2. I don't know if this matters to anyone, I actually think cleartext is superior personally.

### pandoc 1.19.2.1:
![image](https://user-images.githubusercontent.com/129551/32814152-99495968-c962-11e7-9f49-75ab34854c1f.png)

### pandoc 2.0.2:
![image](https://user-images.githubusercontent.com/129551/32814186-b12b8bb4-c962-11e7-870c-e694e83b12fd.png)
