### PR TITLE
Fix #297: Setting background in saveWidget() is broken

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.0
+Version: 1.1
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),

--- a/R/savewidget.R
+++ b/R/savewidget.R
@@ -18,6 +18,13 @@ saveWidget <- function(widget, file, selfcontained = TRUE, libdir = NULL,
                        background = "white", title = class(widget)[[1]],
                        knitrOptions = list()) {
 
+  # Transform #RRGGBB/#RRGGBBAA colors to rgba(r,g,b,a) form, because the
+  # pound sign interferes with pandoc processing
+  if (grepl("^#", background, perl = TRUE)) {
+    bgcol <- col2rgb(background, alpha = TRUE)
+    background <- sprintf("rgba(%d,%d,%d,%f)", bgcol[1,1], bgcol[2,1], bgcol[3,1], bgcol[4,1]/255)
+  }
+
   # convert to HTML tags
   html <- toHTML(widget, standalone = TRUE, knitrOptions = knitrOptions)
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,17 @@
+htmlwidgets 1.1
+-----------------------------------------------------------------------
+
+* The saveWidget's background parameter could not process hex color
+  codes, due to changes introduced in htmlwidgets 1.0. (#297)
+
+
+htmlwidgets 1.0
+-----------------------------------------------------------------------
+
+* Fix issues with self-contained mode when used with new versions of
+  pandoc. (#289)
+
+
 htmlwidgets 0.9
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
Background colors beginning with "#" cause problems in pandoc,
which interprets the # as a level 1 header. Use rgba() form instead.