### PR TITLE
creation without package or without js binding or yaml config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.1
+Version: 1.2
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,26 +59,23 @@ getDependency <- function(name, package = name){
     })
   }
 
-  bindingDir <- system.file("htmlwidgets", package = package)
-  argsDep <- NULL
-  copyBindingDir <- getOption('htmlwidgets.copybindingdir', TRUE)
-  # TODO: remove this trick when htmltools >= 0.3.3 is on CRAN
-  if (copyBindingDir) {
-    if (packageVersion('htmltools') < '0.3.3') {
-      bindingDir <- tempfile("widgetbinding")
-      dir.create(bindingDir, mode = "0700")
-      file.copy(system.file(jsfile, package = package), bindingDir)
-    } else argsDep <- list(all_files = FALSE)
+  # if js binding does not exist then assume provided through
+  #  some other mechanism such as a specified `htmlDependency` or `script` tag.
+  #  Note, this is a very special case.
+  bindingDep <- NULL
+  if(file.exists(system.file(jsfile, package = package))) {
+    bindingDir <- system.file("htmlwidgets", package = package)
+    argsDep <- NULL
+    bindingDep <- do.call(htmlDependency, c(list(
+      paste0(name, "-binding"), packageVersion(package),
+      bindingDir, script = basename(jsfile)
+    ), argsDep))
   }
-  bindingDep <- do.call(htmlDependency, c(list(
-    paste0(name, "-binding"), packageVersion(package),
-    bindingDir, script = basename(jsfile)
-  ), argsDep))
 
   c(
     list(htmlDependency("htmlwidgets", packageVersion("htmlwidgets"),
-      src = system.file("www", package="htmlwidgets"),
-      script = "htmlwidgets.js"
+                        src = system.file("www", package="htmlwidgets"),
+                        script = "htmlwidgets.js"
     )),
     widgetDep,
     list(bindingDep)

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,13 +45,19 @@ getDependency <- function(name, package = name){
   config = sprintf("htmlwidgets/%s.yaml", name)
   jsfile = sprintf("htmlwidgets/%s.js", name)
 
-  config = yaml::yaml.load_file(
-    system.file(config, package = package)
-  )
-  widgetDep <- lapply(config$dependencies, function(l){
-    l$src = system.file(l$src, package = package)
-    do.call(htmlDependency, l)
-  })
+  # if yaml does not exist then assume no dependencies
+  #  in this cases dependencies should be provided through the
+  #  dependencies argument of createWidget
+  widgetDep <- list()
+  if(file.exists(system.file(config, package = package))) {
+    config = yaml::yaml.load_file(
+      system.file(config, package = package)
+    )
+    widgetDep <- lapply(config$dependencies, function(l){
+      l$src = system.file(l$src, package = package)
+      do.call(htmlDependency, l)
+    })
+  }
 
   bindingDir <- system.file("htmlwidgets", package = package)
   argsDep <- NULL

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,11 @@
+htmlwidgets 1.2
+-----------------------------------------------------------------------
+
+* htmlwidgets can be created without a package, without yaml, and/or
+  without JavaScript binding. (#304, #305)
+
+
+
 htmlwidgets 1.1
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
@nstrayer (#305) and @fbreitwieser (#304) motivated this pull request.  While I think this functionality is for a unique and special case, I very much like the idea of ad hoc widget creation without a package or full set of conventions.

### Base Example
For instance, we can do this which is sort of worthless but provides a foundation for later examples.

```
createWidget("awidget", x=NULL)
```

### Limited Functionality but a Widget Still

```
library(htmltools)
library(htmlwidgets)

browsable(
  tagList(
    tags$script(
"
HTMLWidgets.widget({
  name: 'awidget',
  type: 'output',
  factory: function(el, width, height) {
    return {
      renderValue: function(x) {
        el.innerText = x.message;
      },
      resize: function(width, height) { }
    };
  }
});
"
    ),
    createWidget("awidget", x=list(message="I don't need a package, yaml, or js."))
  )
)
```

### Widget With External Dependency

```
library(htmltools)
library(htmlwidgets)
library(d3r)

browsable(
  tagList(
    tags$script(
"
HTMLWidgets.widget({
  name: 'awidget',
  type: 'output',
  factory: function(el, width, height) {
    return {
      renderValue: function(x) {
        var box = d3.select(el).append('svg').append('rect')
          .attr('height', x.size)
          .attr('width', x.size)
          .style('fill', '#c6b')

        setInterval(
          function() {
            var size = box.attr('height') == x.size ? 100 : x.size
            box.transition()
              .attr('height', size)
              .attr('width', size)
          },
          1000
        )
      },
      resize: function(width, height) { }
    };
  }
});
"
    ),
    createWidget("awidget", x=list(size = 300)),
    d3_dep_v4()
  )
)
```
![htmlwidget](https://user-images.githubusercontent.com/837910/38117881-26d50a64-337d-11e8-8452-c80fec177ec5.gif)
