### PR TITLE
Restore the all_files = FALSE argument in htmlDependency()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.2
+Version: 1.2.1
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,14 +62,12 @@ getDependency <- function(name, package = name){
   # if js binding does not exist then assume provided through
   #  some other mechanism such as a specified `htmlDependency` or `script` tag.
   #  Note, this is a very special case.
-  bindingDep <- NULL
-  if(file.exists(system.file(jsfile, package = package))) {
+  bindingDep <- if (file.exists(system.file(jsfile, package = package))) {
     bindingDir <- system.file("htmlwidgets", package = package)
-    argsDep <- NULL
-    bindingDep <- do.call(htmlDependency, c(list(
+    htmlDependency(
       paste0(name, "-binding"), packageVersion(package),
-      bindingDir, script = basename(jsfile)
-    ), argsDep))
+      bindingDir, script = basename(jsfile), all_files = FALSE
+    )
   }
 
   c(

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,11 @@
+htmlwidgets 1.3 (unreleased)
+-----------------------------------------------------------------------
+
+* All files and directories under the `inst/htmlwidgets/` directory of
+  a widget package will be copied when a widget is rendered due to an
+  unintended change in #306. Only the single `WIDGET.js` file should be
+  copied (where `WIDGET` is the widget name). Fixed via #312.
+
 htmlwidgets 1.2
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
When creating the HTML dependency for the JS binding script, we need to make sure only this single script is copied when the widget is rendered (all_files = TRUE is the default, meaning all files/dirs will be copied, which is undesirable).

The issue was introduced in #306.