### PR TITLE
bindings.resize no longer called unnecessarily on first window resize

### DIFF
--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -565,7 +565,10 @@
         }
 
         if (binding.resize) {
-          var lastSize = {};
+          var lastSize = {
+            w: sizeObj ? sizeObj.getWidth() : el.offsetWidth,
+            h: sizeObj ? sizeObj.getHeight() : el.offsetHeight
+          };
           var resizeHandler = function(e) {
             var size = {
               w: sizeObj ? sizeObj.getWidth() : el.offsetWidth,


### PR DESCRIPTION
To reproduce:
1. Open http://www.htmlwidgets.org/showcase_dygraphs.html
2. Open DevTools
3. Set a breakpoint in `htmlwidgets.js` line `582`: `binding.resize(el, size.w, size.h, initResult);`
4. Refresh the page
5. Resize the window
6. Observe your breakpoint gets hit, even though the widget didn't change size

This fix records the initial widget size on the first render so that the first resize event doesn't fire the resize binding.  The motivation to fix this is not for the sake of optimization, but rather to improve any widget which has resize logic that performs large visual changes like animations, etc.