### PR TITLE
Support for Shiny async

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     yaml
 Suggests:
     knitr (>= 1.8)
-Enhances: shiny (>= 1.0.5)
+Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 RoxygenNote: 6.0.1

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -358,7 +358,8 @@ createWidget <- function(name,
 #'   function.
 #' @param reportSize Should the widget's container size be reported in the
 #'   shiny session's client data?
-#' @param expr An expression that generates an HTML widget
+#' @param expr An expression that generates an HTML widget (or a
+#'   \href{https://rstudio.github.io/promises/}{promise} of an HTML widget).
 #' @param env The environment in which to evaluate \code{expr}.
 #' @param quoted Is \code{expr} a quoted expression (with \code{quote()})? This
 #'   is useful if you want to save an expression in a variable.

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -6,6 +6,13 @@ htmlwidgets 1.3 (unreleased)
   unintended change in #306. Only the single `WIDGET.js` file should be
   copied (where `WIDGET` is the widget name). Fixed via #312.
 
+* Support for async Shiny. Widget render functions that use the default
+  implementation of `htmlwidgets::shinyRenderWidget` can receive
+  promises of widget objects (you can, of course, continue to use
+  regular widget objects as well).
+
+  See https://rstudio.github.io/promises for more about async Shiny.
+
 htmlwidgets 1.2
 -----------------------------------------------------------------------
 

--- a/man/htmlwidgets-shiny.Rd
+++ b/man/htmlwidgets-shiny.Rd
@@ -28,7 +28,8 @@ for the output}
 \item{reportSize}{Should the widget's container size be reported in the
 shiny session's client data?}
 
-\item{expr}{An expression that generates an HTML widget}
+\item{expr}{An expression that generates an HTML widget (or a
+\href{https://rstudio.github.io/promises/}{promise} of an HTML widget).}
 
 \item{outputFunction}{Shiny output function corresponding to this render
 function.}


### PR DESCRIPTION
Shiny v1.1 introduced `shiny::createRenderFunction`, which is a more opinionated replacement for `shiny::markRenderFunction`. The advantage of `shiny::createRenderFunction` is that it enables the new async functionality; the user's code expr can now return either a regular widget, or a [promise](https://rstudio.github.io/promises/) for a widget.

Example:

```r
library(shiny)
library(leaflet)
library(promises)
library(future)
plan(multiprocess)

ui <- fluidPage(
  leafletOutput("map")
)

server <- function(input, output, session) {
  output$map <- renderLeaflet({
    future({ Sys.sleep(4); quakes[sample(nrow(quakes), 300),] }) %...>%
      leaflet() %...>%
      addTiles() %...>%
      addMarkers()
  })
}

shinyApp(ui, server)
```

While the future is executing (artificially extended here with a sleep), Shiny is idle and can service other sessions. You can see this by launching this app and then pasting the URL into multiple windows; they should all load quickly.