### PR TITLE
Allow yaml dependencies to be function calls

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,8 +54,12 @@ getDependency <- function(name, package = name){
       system.file(config, package = package)
     )
     widgetDep <- lapply(config$dependencies, function(l){
-      l$src = system.file(l$src, package = package)
-      do.call(htmlDependency, l)
+      if (!is.null(l$call)) {
+        eval(parse(text = l$call), envir = .GlobalEnv)
+      } else {
+        l$src = system.file(l$src, package = package)
+        do.call(htmlDependency, l)
+      }
     })
   }
 


### PR DESCRIPTION
This PR makes it possible for the dependencies .yaml file to point to `htmlDependency` objects that come from other packages, instead of just ones that are bundled in this package.

```
dependencies:
  - call: shiny::bootstrapLib()
```

- [ ] Example
- [ ] Unit tests
- [ ] NEWS