### PR TITLE
Try evaluating code with parentheses before without parentheses

### DIFF
--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,8 @@
+htmlwidgets 1.5.1.9000
+-------------------------------------------------------
+
+* Fixed an issue with passing named function declarations to `JS()` and `onRender()` (introduced by v1.4). (#356)
+
 htmlwidgets 1.5.1
 -------------------------------------------------------
 

--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -249,13 +249,13 @@
   function tryEval(code) {
     var result = null;
     try {
-      result = eval(code);
+      result = eval("(" + code + ")");
     } catch(error) {
       if (!error instanceof SyntaxError) {
         throw error;
       }
       try {
-        result = eval("(" + code + ")");
+        result = eval(code);
       } catch(e) {
         if (e instanceof SyntaxError) {
           throw error;


### PR DESCRIPTION
Closes #356. 

The problem with evaluating without parentheses first is that named function declarations are valid expressions that return undefined (whereas evaluating with parentheses returns the function, as expected).

It's true there may be weird corner-cases where switching this order leads to something else that's undesirable, but we've been operating with the 'with parentheses' model for so long that switching the ordering now will minimize backward-compatibility issues