### PR TITLE
Add reportTheme arg to shinyWidgetOutput()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.5.1.9000
+Version: 1.5.1.9001
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),
@@ -25,4 +25,4 @@ Suggests:
 Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -391,6 +391,15 @@ shinyWidgetOutput <- function(outputId, name, width, height, package = name,
                               inline = FALSE, reportSize = FALSE, reportTheme = FALSE) {
 
   checkShinyVersion()
+
+  # Theme reporting requires this shiny feature
+  # https://github.com/rstudio/shiny/pull/2740/files
+  if (reportTheme &&
+      nzchar(system.file(package = "shiny")) &&
+      packageVersion("shiny") < "1.4.0.9003") {
+    message("`reportTheme = TRUE` requires shiny v.1.4.0.9003 or higher. Consider upgrading shiny.")
+  }
+
   # generate html
   html <- htmltools::tagList(
     widget_html(

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -358,6 +358,8 @@ createWidget <- function(name,
 #'   function.
 #' @param reportSize Should the widget's container size be reported in the
 #'   shiny session's client data?
+#' @param reportTheme Should the widget's container styles (e.g., colors and fonts)
+#' be reported in the shiny session's client data?
 #' @param expr An expression that generates an HTML widget (or a
 #'   \href{https://rstudio.github.io/promises/}{promise} of an HTML widget).
 #' @param env The environment in which to evaluate \code{expr}.
@@ -386,13 +388,18 @@ createWidget <- function(name,
 #'
 #' @export
 shinyWidgetOutput <- function(outputId, name, width, height, package = name,
-                              inline = FALSE, reportSize = FALSE) {
+                              inline = FALSE, reportSize = FALSE, reportTheme = FALSE) {
 
   checkShinyVersion()
   # generate html
   html <- htmltools::tagList(
-    widget_html(name, package, id = outputId,
-      class = paste0(name, " html-widget html-widget-output", if (reportSize) " shiny-report-size"),
+    widget_html(
+      name, package, id = outputId,
+      class = paste0(
+        name, " html-widget html-widget-output",
+        if (reportSize) " shiny-report-size",
+        if (reportTheme) " shiny-report-theme"
+      ),
       style = sprintf("width:%s; height:%s; %s",
         htmltools::validateCssUnit(width),
         htmltools::validateCssUnit(height),

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,6 +3,8 @@ htmlwidgets 1.5.1.9000
 
 * Fixed an issue with passing named function declarations to `JS()` and `onRender()` (introduced by v1.4). (#356)
 
+* Added a `reportTheme` argument to `shinyWidgetOutput()`. If `TRUE`, CSS styles of the widget's output container are made available to `shiny::getCurrentOutput()`, making it possible to provide 'smart' styling defaults in a `renderWidget()` context. (#361)
+
 htmlwidgets 1.5.1
 -------------------------------------------------------
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,7 +3,7 @@ htmlwidgets 1.5.1.9000
 
 * Fixed an issue with passing named function declarations to `JS()` and `onRender()` (introduced by v1.4). (#356)
 
-* Added a `reportTheme` argument to `shinyWidgetOutput()`. If `TRUE`, CSS styles of the widget's output container are made available to `shiny::getCurrentOutput()`, making it possible to provide 'smart' styling defaults in a `renderWidget()` context. (#361)
+* Added a `reportTheme` argument to `shinyWidgetOutput()`. If `TRUE`, CSS styles of the widget's output container are made available to `shiny::getCurrentOutputInfo()`, making it possible to provide 'smart' styling defaults in a `renderWidget()` context. (#361)
 
 htmlwidgets 1.5.1
 -------------------------------------------------------

--- a/man/createWidget.Rd
+++ b/man/createWidget.Rd
@@ -4,9 +4,17 @@
 \alias{createWidget}
 \title{Create an HTML Widget}
 \usage{
-createWidget(name, x, width = NULL, height = NULL,
-  sizingPolicy = htmlwidgets::sizingPolicy(), package = name,
-  dependencies = NULL, elementId = NULL, preRenderHook = NULL)
+createWidget(
+  name,
+  x,
+  width = NULL,
+  height = NULL,
+  sizingPolicy = htmlwidgets::sizingPolicy(),
+  package = name,
+  dependencies = NULL,
+  elementId = NULL,
+  preRenderHook = NULL
+)
 }
 \arguments{
 \item{name}{Widget name (should match the base name of the YAML and

--- a/man/htmlwidgets-shiny.Rd
+++ b/man/htmlwidgets-shiny.Rd
@@ -6,8 +6,16 @@
 \alias{shinyRenderWidget}
 \title{Shiny bindings for HTML widgets}
 \usage{
-shinyWidgetOutput(outputId, name, width, height, package = name,
-  inline = FALSE, reportSize = FALSE)
+shinyWidgetOutput(
+  outputId,
+  name,
+  width,
+  height,
+  package = name,
+  inline = FALSE,
+  reportSize = FALSE,
+  reportTheme = FALSE
+)
 
 shinyRenderWidget(expr, outputFunction, env, quoted)
 }
@@ -25,8 +33,8 @@ string and have \code{"px"} appended.}
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
 
-\item{reportSize}{Should the widget's container size be reported in the
-shiny session's client data?}
+\item{reportSize}{Should the widget's container styles (e.g., background
+/foreground color) be reported in the shiny session's client data?}
 
 \item{expr}{An expression that generates an HTML widget (or a
 \href{https://rstudio.github.io/promises/}{promise} of an HTML widget).}

--- a/man/saveWidget.Rd
+++ b/man/saveWidget.Rd
@@ -4,9 +4,15 @@
 \alias{saveWidget}
 \title{Save a widget to an HTML file}
 \usage{
-saveWidget(widget, file, selfcontained = TRUE, libdir = NULL,
-  background = "white", title = class(widget)[[1]],
-  knitrOptions = list())
+saveWidget(
+  widget,
+  file,
+  selfcontained = TRUE,
+  libdir = NULL,
+  background = "white",
+  title = class(widget)[[1]],
+  knitrOptions = list()
+)
 }
 \arguments{
 \item{widget}{Widget to save}

--- a/man/sizingPolicy.Rd
+++ b/man/sizingPolicy.Rd
@@ -4,15 +4,25 @@
 \alias{sizingPolicy}
 \title{Create a widget sizing policy}
 \usage{
-sizingPolicy(defaultWidth = NULL, defaultHeight = NULL,
-  padding = NULL, viewer.defaultWidth = NULL,
-  viewer.defaultHeight = NULL, viewer.padding = NULL,
-  viewer.fill = TRUE, viewer.suppress = FALSE,
-  viewer.paneHeight = NULL, browser.defaultWidth = NULL,
-  browser.defaultHeight = NULL, browser.padding = NULL,
-  browser.fill = FALSE, browser.external = FALSE,
-  knitr.defaultWidth = NULL, knitr.defaultHeight = NULL,
-  knitr.figure = TRUE)
+sizingPolicy(
+  defaultWidth = NULL,
+  defaultHeight = NULL,
+  padding = NULL,
+  viewer.defaultWidth = NULL,
+  viewer.defaultHeight = NULL,
+  viewer.padding = NULL,
+  viewer.fill = TRUE,
+  viewer.suppress = FALSE,
+  viewer.paneHeight = NULL,
+  browser.defaultWidth = NULL,
+  browser.defaultHeight = NULL,
+  browser.padding = NULL,
+  browser.fill = FALSE,
+  browser.external = FALSE,
+  knitr.defaultWidth = NULL,
+  knitr.defaultHeight = NULL,
+  knitr.figure = TRUE
+)
 }
 \arguments{
 \item{defaultWidth}{The default width used to display the widget. This


### PR DESCRIPTION
Will make it easier for widget authors to get at the theming info behind  https://github.com/rstudio/shiny/pull/2740