### PR TITLE
Avoid error in find_pandoc() by replacing file.exists() with dir.exis…

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -174,7 +174,7 @@ find_pandoc <- function() {
 
     # determine the versions of the sources
     versions <- lapply(sources, function(src) {
-      if (file.exists(src))
+      if (dir.exists(src))
         get_pandoc_version(src)
       else
         numeric_version("0")


### PR DESCRIPTION
…ts()

Since 'pandoc' is appended to src in find_version(src) before querying for the version, the paths in sources are required to point to the directory of the pandoc executable. Thus, a check by dir.exists(src) instead of the current file.exists(src) seems more appropriate. In particular, it avoids an error if src points the the pandoc executable itself instead of the directory.