### PR TITLE
Update widget_html

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("JJ", "Allaire", role = c("aut")),
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
     person("Kenton", "Russell", role = c("aut", "cph")),
+    person("Ellis", "Hughes", role = c("ctb")),
     person(family = "RStudio", role = "cph")
     )
 Description: A framework for creating HTML widgets that render in various

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -239,15 +239,6 @@ widget_html_wrapper <- function(name, package, id, style, class, inline = FALSE,
     inline = inline,
     ...)
 
-  if(!inherits(fn_res,c("shiny.tag","shiny.tag.list"))){
-    warning(
-      paste0("widget_html.",name),
-      " returned an object of class `",
-      deparse(class(fn_res)),
-      "` instead of a `shiny.tag`."
-    )
-  }
-
   fn_res
 
 }
@@ -265,6 +256,7 @@ widget_html.default <- function (name, package, id, style, class, inline = FALSE
                  error = function(e) NULL)
 
   if (is.function(fn)) {
+
     .Deprecated(
       new = paste0("widget_html.",name),
       package = package,
@@ -274,7 +266,17 @@ widget_html.default <- function (name, package, id, style, class, inline = FALSE
                   "See docs for details at http://www.htmlwidgets.org/develop_advanced.html"),
       old = paste0(name, "_html")
     )
+
     fn(id = id, style = style, class = class, ...)
+
+    if(!inherits(fn_res,c("shiny.tag","shiny.tag.list"))){
+      warning(
+        paste0("widget_html.",name),
+        " returned an object of class `",
+        deparse(class(fn_res)),
+        "` instead of a `shiny.tag`."
+      )
+    }
 
   } else if (inline) {
     tags$span(id = id, style = style, class = class)


### PR DESCRIPTION
Addresses #376

Suggested two updates to widget_html that are implemented here:
 - To behave like an s3 method where it will look up the "type" of method it should use. This uses the "name" field to determine. Minimal changes from current *name*_html method.
 - Add an object output type checker for custom functions to make sure they return a `shiny.tag`. Throws a warning describing what it saw and what it expected. 

We could add a soft-deprication for the current method (*name*_html) if you want. I wasn't sure how we might want to do that. 
- Add a check for the 'current' method and throw a warning? That might alarm users as opposed to the authors though
- Open to ideas!