### PR TITLE
Pseudo S3 widget_html dispatch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),
     person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),
     person("Kenton", "Russell", role = c("aut", "cph")),
+    person("Ellis", "Hughes", role = c("ctb")),
     person(family = "RStudio", role = "cph")
     )
 Description: A framework for creating HTML widgets that render in various

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     yaml
 Suggests:
     knitr (>= 1.8),
-    rmarkdown
+    rmarkdown,
     testthat
 Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
 Suggests:
     knitr (>= 1.8),
     rmarkdown
+    testthat
 Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### HTML Widgets for R
 
 <!-- badges: start -->
-[![R build status](https://github.com/cpsievert/htmlwidgets/workflows/R-CMD-check/badge.svg)](https://github.com/cpsievert/htmlwidgets/actions)
+[![R build status](https://github.com/ramnathv/htmlwidgets/workflows/R-CMD-check/badge.svg)](https://github.com/ramnathv/htmlwidgets/actions)
 [![CRAN status](https://www.r-pkg.org/badges/version/htmlwidgets)](https://CRAN.R-project.org/package=htmlwidgets)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
 <!-- badges: end -->

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -9,6 +9,8 @@ htmlwidgets 1.5.2.9000
 
 * `shinyRenderWidget()` now has a `cacheHint` parameter, for use with Shiny's new `bindCache()` function. (#391)
 
+* Support a new `PACKAGE::widget_html.WIDGETNAME` convention for defining custom widget HTML. This replaces the earlier `PACKAGE::WIDGETNAME_html` convention, which continues to work but may be deprecated at some point in the future. The goal for the new convention is to prevent accidentally matching functions that were never intended for this purpose. (Thanks, @thebioengineer!) (#376)
+
 htmlwidgets 1.5.2
 -------------------------------------------------------
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(htmlwidgets)
+
+test_check("htmlwidgets")

--- a/tests/testthat/test-htmlwidgets.R
+++ b/tests/testthat/test-htmlwidgets.R
@@ -1,0 +1,44 @@
+test_that("Legacy widget html methods work", {
+  # Finds htmlwidgets:::widgetA_html()
+  res <- widget_html("widgetA", "htmlwidgets", id = "id", style = NULL, class = NULL)
+  expect_identical(res$name, "canvas")
+})
+
+test_that("Legacy widget html methods are warned on unexpected output type", {
+  expect_warning(
+    res <- widget_html("widgetB", "htmlwidgets", id = "id", style = NULL, class = NULL),
+    "widgetB_html returned an object of class `logical` instead of a `shiny.tag`.",
+    fixed = TRUE
+  )
+  expect_identical(res, TRUE)
+})
+
+test_that("New-style widget html method works, and is preferred", {
+  # widgetC has both widgetC_html and widget_html.widgetC, and they return
+  # differing results. Make sure that widget_html.widgetC is the one that's
+  # actually called.
+  res <- widget_html("widgetC", "htmlwidgets", id = "id", style = NULL, class = NULL)
+  expect_identical(
+    res,
+    widget_html.widgetC("widgetC", "htmlwidgets", id = "id", style = NULL, class = NULL))
+})
+
+test_that("New-style widget html methods do not trigger warning on non-tag output", {
+  expect_warning(
+    res <- widget_html("widgetD", "htmlwidgets", id = "id", style = NULL, class = NULL),
+    NA
+  )
+  expect_identical(res, TRUE)
+})
+
+test_that("Fallback logic still works", {
+  res <- widget_html("does_not_exist", "htmlwidgets", id = "id", style = NULL, class = NULL)
+  expect_identical(res, tags$div(id = "id"))
+})
+
+test_that("Legacy methods work with tagList() and HTML()", {
+  expect_warning({
+    widget_html("widgetE", "htmlwidgets", id = "id", style = NULL, class = NULL)
+    widget_html("widgetF", "htmlwidgets", id = "id", style = NULL, class = NULL)
+  }, NA)
+})

--- a/vignettes/develop_advanced.Rmd
+++ b/vignettes/develop_advanced.Rmd
@@ -177,12 +177,14 @@ If multiple arguments are passed to `JS()` (as in the above example), they will 
 Typically the HTML "housing" for a widget is just a `<div>` element, and this is correspondingly the default behavior for new widgets that don't specify otherwise. However, sometimes you need a different element type. For example, the [sparkline](https://github.com/htmlwidgets/sparkline) widget requires a `<span>` element so implements the following custom HTML generation function:
 
 ```r
-sparkline_html <- function(id, style, class, ...){
+widget_html.sparkline <- function(id, style, class, ...){
   tags$span(id = id, class = class)
 }
 ```
 
-Note that this function is looked up within the package implementing the widget by the convention `widgetname_html` so it need not be formally exported from your package or otherwise registered with **htmlwidgets**.
+Note that this function is looked up within the package implementing the widget by the convention <code>widget_html.<em>widgetname</em></code> so it need not be formally exported from your package or otherwise registered with **htmlwidgets**.
+
+(**htmlwidgets** 1.5.1 and earlier used a convention of <code><em>widgetname</em>_html</code>. This is still supported for now, but the new <code>widget_html.<em>widgetname</em></code> convention is recommended going forward, as it seems less likely to lead to false positives.)
 
 Most widgets won't need a custom HTML function but if you need to generate custom HTML for your widget (e.g. you need an `<input>` or a `<span>` rather than a `<div>`) then you should use the **htmltools** package (as demonstrated by the code above).
 

--- a/vignettes/develop_advanced.Rmd
+++ b/vignettes/develop_advanced.Rmd
@@ -184,7 +184,6 @@ widget_html.sparkline <- function(id, style, class, ...){
 
 Note that this function is looked up within the package implementing the widget by the convention <code>widget_html.<em>widgetname</em></code> so it need not be formally exported from your package or otherwise registered with **htmlwidgets**.
 
-(**htmlwidgets** 1.5.1 and earlier used a convention of <code><em>widgetname</em>_html</code>. This is still supported for now, but the new <code>widget_html.<em>widgetname</em></code> convention is recommended going forward, as it seems less likely to lead to false positives.)
+(**htmlwidgets** 1.5.2 and earlier used a convention of <code><em>widgetname</em>_html</code>. This is still supported for now, but the new <code>widget_html.<em>widgetname</em></code> convention is recommended going forward, as it seems less likely to lead to false positives.)
 
 Most widgets won't need a custom HTML function but if you need to generate custom HTML for your widget (e.g. you need an `<input>` or a `<span>` rather than a `<div>`) then you should use the **htmltools** package (as demonstrated by the code above).
-


### PR DESCRIPTION
Addresses #376, succeeds #377 

- If `PACKAGE:::widget_html.WIDGETNAME` exists, use it. Else,
- If `PACKAGE:::WIDGETNAME_html` exists, use it, and warn if the results aren't a tag, tag list, or `HTML()`. Else,
- Use `htmlwidgets:::widget_html.default`.