### PR TITLE
shinyRenderWidget: Add support for caching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmlwidgets
 Type: Package
 Title: HTML Widgets for R
-Version: 1.5.2.9000
+Version: 1.5.2.9001
 Authors@R: c(
     person("Ramnath", "Vaidyanathan", role = c("aut", "cph")),
     person("Yihui", "Xie", role = c("aut")),

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -429,7 +429,7 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
 
   checkShinyVersion()
   # generate a function for the expression
-  func <- shiny::exprToFunction(expr, env, quoted)
+  shiny::installExprFunction(expr, "func", env, quoted)
 
   renderWidget <- function(instance) {
     if (!is.null(instance$elementId)) {
@@ -463,19 +463,14 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted) {
     toJSON(payload)
   }
 
-  if (!is.null(asNamespace("shiny")$createRenderFunction)) {
-    shiny::createRenderFunction(
-      func,
-      function(instance, session, name, ...) {
-        renderWidget(instance)
-      },
-      outputFunction, NULL
-    )
-  } else {
-    shiny::markRenderFunction(outputFunction, function() {
-      renderWidget(func())
-    })
-  }
+  shiny::createRenderFunction(
+    func,
+    function(instance, session, name, ...) {
+      renderWidget(instance)
+    },
+    outputFunction,
+    NULL
+  )
 }
 
 checkShinyVersion <- function(error = TRUE) {

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -366,7 +366,7 @@ createWidget <- function(name,
 #' @param quoted Is \code{expr} a quoted expression (with \code{quote()})? This
 #'   is useful if you want to save an expression in a variable.
 #' @param cacheHint Extra information to use for optional caching using
-#'   \code{\link[shiny]{withCache}}.
+#'   \code{\link[shiny]{bindCache}}.
 #'
 #' @return An output or render function that enables the use of the widget
 #'   within Shiny applications.

--- a/man/htmlwidgets-shiny.Rd
+++ b/man/htmlwidgets-shiny.Rd
@@ -51,7 +51,7 @@ function.}
 is useful if you want to save an expression in a variable.}
 
 \item{cacheHint}{Extra information to use for optional caching using
-\code{\link[shiny]{withCache}}.}
+\code{\link[shiny]{bindCache}}.}
 }
 \value{
 An output or render function that enables the use of the widget

--- a/man/htmlwidgets-shiny.Rd
+++ b/man/htmlwidgets-shiny.Rd
@@ -17,7 +17,7 @@ shinyWidgetOutput(
   reportTheme = FALSE
 )
 
-shinyRenderWidget(expr, outputFunction, env, quoted)
+shinyRenderWidget(expr, outputFunction, env, quoted, cacheHint = "auto")
 }
 \arguments{
 \item{outputId}{output variable to read from}
@@ -49,6 +49,9 @@ function.}
 
 \item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
+
+\item{cacheHint}{Extra information to use for optional caching using
+\code{\link[shiny]{withCache}}.}
 }
 \value{
 An output or render function that enables the use of the widget


### PR DESCRIPTION
Switching from `exprToFunction` to `installExprFunction` will make it possible for htmlwidgets to benefit from Shiny's new `bindCache` and `bindEvent` functions.

It also removes a check for the existence of `createRenderFunction`, which was added in Shiny 1.1.0 (and was released 2018-05).