### PR TITLE
Remove indentation when rendering HTML into pandoc

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -26,7 +26,7 @@ pandoc_save_markdown <- function(html, file, background = "white", title, libdir
     on.exit(setwd(owd), add = TRUE)
   }
 
-  rendered <- renderTags(html)
+  rendered <- renderTags(html, indent = FALSE)
 
   deps <- lapply(rendered$dependencies, function(dep) {
     dep <- htmltools::copyDependencyToDir(dep, libdir, FALSE)


### PR DESCRIPTION
When the html object contains nested tags, the default behaviour is for renderTags to indent the code. This causes an issue when the generated text is parsed by pandoc later on. Pandoc parses the indented block as "Verbatim (code) blocks", escaping it as text in the HTML and wrapping it in `<pre><code>` tags, The result is a non-functional widget.

To avoid this, set indent = FALSE in the call to renderTags, avoiding this opportunity for pandoc to misinterpret the input file. 
Believe that this fixes #358
