### PR TITLE
Re-register HTML dependencies on cache read

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -564,8 +564,6 @@ shinyRenderWidget <- function(expr, outputFunction, env, quoted, cacheHint = "au
         )
         value
       }
-
-
     )
   } else {
     shiny::createRenderFunction(
@@ -603,4 +601,3 @@ createPayload <- function(instance){
 
 # package globals
 .globals <- new.env(parent = emptyenv())
-


### PR DESCRIPTION
Fixes #396. This depends on https://github.com/rstudio/shiny/pull/3173.