### PR TITLE
Protect HTML from markdown parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@ htmlwidgets 1.5.4.9000
   * Widgets that aren't designed to fill their container in this way should consider setting `sizingPolicy(fill = FALSE)`/`shinyWidgetOutput(fill = FALSE)` and/or allowing users to customize these settings (i.e., add a `fill` argument to the `customWidgetOutput()` function signature).
 * `shinyWidgetOutput()`'s `reportSize` argument now defaults to `TRUE`. This way, calling `shiny::getCurrentOutputInfo()` inside a `shinyRenderWidget()` context will report the current height and width of the widget.
 
+### Bug fixes
+
+* Closed #257 and #358: `saveWidget(selfcontained=TRUE)` now correctly prevents HTML from being interpreted as markdown. (#401)
 
 htmlwidgets 1.5.4
 -------------------------------------------------------

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -14,7 +14,7 @@ write_md_for_pandoc <- function(html, file, background = "white", title, libdir 
   # 4 characters or more was being interpreted by pandoc_self_contained_html as
   # markdown code blocks. We have two strategies for dealing with this, but the
   # better one only works with pandoc >=2.0.
-  if (pandoc_available("2.0")) {
+  if (rmarkdown::pandoc_available("2.0")) {
     # Preferred strategy is to keep indenting the HTML (indent = 0 doesn't turn
     # off indentation, it just means the indentation level starts at 0), and use
     # a raw block (```{=html}...```) to protect the HTML from markdown parser.

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -10,7 +10,7 @@ write_md_for_pandoc <- function(html, file, background = "white", title, libdir 
     on.exit(setwd(owd), add = TRUE)
   }
 
-  rendered <- renderTags(html)
+  rendered <- renderTags(html, indent = FALSE)
 
   deps <- lapply(rendered$dependencies, function(dep) {
     dep <- htmltools::copyDependencyToDir(dep, libdir, FALSE)

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -1,4 +1,4 @@
-write_md_for_pandoc <- function(html, file, background = "white", title, libdir = "lib") {
+write_md_for_pandoc <- function(html, file, background = "white", title, libdir = "lib", use_raw_attr = rmarkdown::pandoc_available("2.0")) {
   # Forked from htmltools::save_html to work better with pandoc_self_contained_html
 
   # ensure that the paths to dependencies are relative to the base
@@ -14,16 +14,14 @@ write_md_for_pandoc <- function(html, file, background = "white", title, libdir 
   # 4 characters or more was being interpreted by pandoc_self_contained_html as
   # markdown code blocks. We have two strategies for dealing with this, but the
   # better one only works with pandoc >=2.0.
-  if (rmarkdown::pandoc_available("2.0")) {
+  if (use_raw_attr) {
     # Preferred strategy is to keep indenting the HTML (indent = 0 doesn't turn
     # off indentation, it just means the indentation level starts at 0), and use
     # a raw block (```{=html}...```) to protect the HTML from markdown parser.
     indent <- 0
-    use_raw_attr <- TRUE
   } else {
     # Legacy pandoc doesn't support raw blocks, so just turn off indentation
     indent <- FALSE
-    use_raw_attr <- FALSE
   }
 
   rendered <- renderTags(html, indent = indent)

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -1,31 +1,24 @@
-test_358 <- function() {
+test_that("Fix for issue #358 works", {
+  skip_if_not(
+    rmarkdown::pandoc_available(),
+    "Test requires pandoc to be installed"
+  )
+
   file <- tempfile(fileext = ".html")
-  html <- htmltools::withTags(
+  html <- div(
     div(
       div(
         div(
           div(
-            div(
-              "Hello"
-            )
+            "Hello"
           )
         )
       )
     )
   )
 
-  pandoc_save_markdown(html, file, title = "test")
+  write_md_for_pandoc(html, file, title = "test")
   pandoc_self_contained_html(file, file)
-  browseURL(file)
   lines <- readLines(file)
   expect_false(any(grepl("<pre", lines)))
-}
-
-test_that("Fix for issue #358 works", {
-  test_358()
-
-  orig_version <- .pandoc$version
-  on.exit(.pandoc$version <- orig_version, add = TRUE)
-  .pandoc$version <- "1.9"
-  test_358()
 })

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -17,8 +17,15 @@ test_that("Fix for issue #358 works", {
     )
   )
 
-  write_md_for_pandoc(html, file, title = "test")
-  pandoc_self_contained_html(file, file)
-  lines <- readLines(file)
+  get_pandoc_html <- function(html, file, title = "test", ...) {
+    write_md_for_pandoc(html, file, title = title, ...)
+    pandoc_self_contained_html(file, file)
+    readLines(file)
+  }
+
+  lines <- get_pandoc_html(html, file)
+  expect_false(any(grepl("<pre", lines)))
+
+  lines <- get_pandoc_html(html, file, use_raw_attr = FALSE)
   expect_false(any(grepl("<pre", lines)))
 })

--- a/tests/testthat/test-pandoc.R
+++ b/tests/testthat/test-pandoc.R
@@ -1,0 +1,31 @@
+test_358 <- function() {
+  file <- tempfile(fileext = ".html")
+  html <- htmltools::withTags(
+    div(
+      div(
+        div(
+          div(
+            div(
+              "Hello"
+            )
+          )
+        )
+      )
+    )
+  )
+
+  pandoc_save_markdown(html, file, title = "test")
+  pandoc_self_contained_html(file, file)
+  browseURL(file)
+  lines <- readLines(file)
+  expect_false(any(grepl("<pre", lines)))
+}
+
+test_that("Fix for issue #358 works", {
+  test_358()
+
+  orig_version <- .pandoc$version
+  on.exit(.pandoc$version <- orig_version, add = TRUE)
+  .pandoc$version <- "1.9"
+  test_358()
+})


### PR DESCRIPTION
This builds on #395, preserving indentation when possible. 

Closes #358
Closes https://github.com/ramnathv/htmlwidgets/issues/257