### PR TITLE
This patch allows htmlwidgets to display in pkgdown sites.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 RoxygenNote: 7.1.1
-Remotes: dmurdoch/downlit@rglpatch, dmurdoch/pkgdown@rglpatch
+Remotes: r-lib/downlit, r-lib/pkgdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,11 @@ Imports:
 Suggests:
     knitr (>= 1.8),
     downlit,
+    pkgdown,
     rmarkdown,
     testthat
 Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 RoxygenNote: 7.1.1
+Remotes: dmurdoch/downlit@rglpatch, dmurdoch/pkgdown@figures

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 RoxygenNote: 7.1.1
-Remotes: dmurdoch/downlit@rglpatch, dmurdoch/pkgdown@figures
+Remotes: dmurdoch/downlit@rglpatch, dmurdoch/pkgdown@rglpatch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     yaml
 Suggests:
     knitr (>= 1.8),
+    downlit,
     rmarkdown,
     testthat
 Enhances: shiny (>= 1.1)

--- a/R/knitr-methods.R
+++ b/R/knitr-methods.R
@@ -29,7 +29,9 @@ registerMethods <- function(methods) {
   # htmlwidgets and knitr are loaded.
   registerMethods(list(
     # c(package, genname, class)
-    c("knitr", "knit_print", "htmlwidget")
+    c("knitr", "knit_print", "htmlwidget"),
+    c("downlit", "replay_html", "htmlwidget"),
+    c("pkgdown", "pkgdown_print", "htmlwidget")
   ))
 }
 

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -1,0 +1,14 @@
+# These methods allow htmlwidget displays to appear in pkgdown
+# web sites.
+
+replay_html.htmlwidget <- function(x, ...) {
+  rendered <- htmltools::renderTags(x)
+  structure(rendered$html, dependencies = rendered$dependencies)
+}
+
+pkgdown_print.htmlwidget <- function(x, visible = TRUE) {
+  if (visible)
+    x
+  else
+    invisible(NULL)
+}

--- a/R/sizing.R
+++ b/R/sizing.R
@@ -225,6 +225,14 @@ resolveSizing <- function(x, sp, standalone, knitrOptions = NULL) {
       width = x$width %||% figWidth %||% any_prop(knitrScopes, "defaultWidth") %||% DEFAULT_WIDTH,
       height = x$height %||% figHeight %||% any_prop(knitrScopes, "defaultHeight") %||% DEFAULT_HEIGHT
     ))
+  } else if (requireNamespace("pkgdown", quietly = TRUE) &&
+             pkgdown::in_pkgdown() &&
+             "fig_settings" %in% getNamespaceExports("pkgdown")) {
+    settings <- pkgdown::fig_settings()
+    return(list(
+      width = x$width %||% with(settings, fig.width*dpi) %||% DEFAULT_WIDTH,
+      height = x$height %||% with(settings, fig.height*dpi) %||% DEFAULT_HEIGHT
+    ))
   } else {
     # Some non-knitr, non-print scenario.
     # Just resolve the width/height vs. defaultWidth/defaultHeight


### PR DESCRIPTION
It requires the corresponding branch of downlit and pkgdown to have been installed:

    remotes::install_github("dmurdoch/downlit@rglpatch")
    remotes::install_github("dmurdoch/pkgdown@rglpatch")

PR's have been sent to those two packages.