### PR TITLE
`shinyWidgetOutput()` should pass `width`/`height` along to `widget_html()`

### DIFF
--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -499,7 +499,9 @@ shinyWidgetOutput <- function(outputId, name, width, height, package = name,
       width = validateCssUnit(width),
       height = validateCssUnit(height),
       display = if (inline) "inline-block"
-    )
+    ),
+    width = width,
+    height = height
   )
 
   tag <- bindFillRole(tag, item = fill)


### PR DESCRIPTION
Closes #449 (introduced by https://github.com/ramnathv/htmlwidgets/commit/cc6504a5b1f53b7c76ee774fae16b5fd0977f1ab)