### PR TITLE
Move rmarkdown from Suggests to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,10 +21,10 @@ Imports:
     grDevices,
     htmltools (>= 0.5.3.9001),
     jsonlite (>= 0.9.16),
-    yaml
-Suggests:
+    yaml,
     knitr (>= 1.8),
-    rmarkdown,
+    rmarkdown
+Suggests:
     testthat
 Enhances: shiny (>= 1.1)
 URL: https://github.com/ramnathv/htmlwidgets

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ htmlwidgets 1.5.4.9000
 
 ### Potentially breaking changes
 
-* Closed #433 and #440: `saveWidget(selfcontained=TRUE)` now requires the `{rmarkdown}` package to discover and call pandoc, which fixes a couple existing issues and helps "future proof" this code path from future changes to pandoc.
+* Closed #433 and #440: `saveWidget(selfcontained=TRUE)` now uses the `{rmarkdown}` package to discover and call pandoc, which fixes a couple existing issues and helps "future proof" this code path from future changes to pandoc.
 * `shinyWidgetOutput()` and `sizingPolicy()` both gain a new `fill` parameter. When `TRUE` (the default), the widget's container element is allowed to grow/shrink to fit it's parent container so long as that parent is opinionated about its height and has been marked with `htmltools::bindFillRole(x, container = TRUE)`. (#442)
   * The primary motivation for this is to allow widgets to grow/shrink by default [inside `bslib::card_body_fill()`](https://rstudio.github.io/bslib/articles/cards.html#responsive-sizing)
   * Widgets that aren't designed to fill their container in this way should consider setting `sizingPolicy(fill = FALSE)`/`shinyWidgetOutput(fill = FALSE)` and/or allowing users to customize these settings (i.e., add a `fill` argument to the `customWidgetOutput()` function signature).

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -60,13 +60,6 @@ write_md_for_pandoc <- function(html, file, background = "white", title, libdir 
 # The input should be the path to a file that was created using pandoc_save_markdown
 pandoc_self_contained_html <- function(input, output) {
 
-  if (!is_installed("rmarkdown")) {
-    stop(
-      "Saving a widget with selfcontained = TRUE requires the rmarkdown package. ",
-      "Install it with `install.packages('rmarkdown')`"
-    )
-  }
-
   if (!rmarkdown::pandoc_available()) {
     stop(
       "Saving a widget with selfcontained = TRUE requires pandoc. ",


### PR DESCRIPTION
This "temporary solution" of moving rmarkdown from Suggests to Imports will make it so existing `saveWidget(selfcontained = TRUE)` code won't error out when `{rmarkdown}` isn't installed.

However, longer term, `saveWidget()` should probably be a basic wrapper around `htmltools::save_html()` (and `{htmltools}` should probably use `{pandoc}` instead of `{rmarkdown}`). In that case, we'll be able to move rmarkdown back to Suggets. See https://github.com/rstudio/htmltools/issues/73 for more
