### PR TITLE
Search for `JS()` calls recursively only in explicit lists and data.frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 htmlwidgets 1.6.2.9000
 ------------------------------------------------------
 
+### Potentially breaking changes
+
+* Closed #466: htmlwidgets no longer recurses into list-like objects when searching for JavaScript strings wrapped in `JS()`, unless the object has the class `"list"` or `"data.frame"`. This stops htmlwidgets from (possibly infinitely) recursively searching objects that are not actually recursive. Widget authors who relied on the previous behavior should ensure that their widget's `JS()` calls are wrapped in objects that have the class `"list"` or `"data.frame"`. (#467)
+
 
 htmlwidgets 1.6.2
 ------------------------------------------------------

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,7 +165,7 @@ shouldEval <- function(options) {
     if ((n <- length(options)) == 0) return(FALSE)
     # use numeric indices as names (remember JS indexes from 0, hence -1 here)
     if (is.null(names(options)))
-      names(options) <- seq_len(n) - 1L
+      names(options) <- as.character(seq_len(n) - 1L)
     # Escape '\' and '.' by prefixing them with '\'. This allows us to tell the
     # difference between periods as separators and periods that are part of the
     # name itself.

--- a/R/utils.R
+++ b/R/utils.R
@@ -161,7 +161,7 @@ JSEvals <- function(list) {
 #' @noRd
 #' @keywords internal
 shouldEval <- function(options) {
-  if (is.list(options)) {
+  if (inherits(options, c("list", "data.frame"))) {
     if ((n <- length(options)) == 0) return(FALSE)
     # use numeric indices as names (remember JS indexes from 0, hence -1 here)
     if (is.null(names(options)))


### PR DESCRIPTION
Fixes #466 by avoids recursion of list-like objects that aren't actually lists, as suggested by @DavisVaughn.

Recursion over data.frames is uncommon but was previously supported and list columns can, in theory, contain `JS()` code.

The core issue from #466 is the assignment of integers to `names(options)`, which was a `clock_calendar` object. Casting to character before assignment is safer, but doesn't completely solve the problem and in fact provides further evidence that we should be more selective about recursion becaues `cals` is infinitely recusable:

```r
cals = clock::year_quarter_day(year = 2000:2001, quarter = 2)
identical(cals[[1]], cals[[1]][[1]])
#> [1] TRUE
```

In summary, after this change, `shouldEval()` only enters explicit lists and data.frames to search for `JS()` (`JS_EVAL`) objects.