### PR TITLE
Add "aria-labelledby" attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,14 @@
 htmlwidgets 1.6.2.9000
 ------------------------------------------------------
 
+* Added `aria-labelledby` attribute to the `widget_html.default()` 
+output to work with accessibility improvements in `knitr` version 
+1.42.12.
 
 htmlwidgets 1.6.2
 ------------------------------------------------------
 
-* Closed #452: `as.tag.htmlwidget()` now includes `...` in it's function signature (for compatibility with the `htmltools::as.tags` generic).
+* Closed #452: `as.tag.htmlwidget()` now includes `...` in its function signature (for compatibility with the `htmltools::as.tags` generic).
 
 htmlwidgets 1.6.1
 ------------------------------------------------------

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -286,9 +286,11 @@ widget_html <- function(name, package, id, style, class, inline = FALSE, ...) {
 
 widget_html.default <- function (name, package, id, style, class, inline = FALSE, ...) {
   if (inline) {
-    tags$span(id = id, style = style, class = class)
+    tags$span(id = id, style = style, class = class,
+              "aria-labelledby" = paste0(id, "-aria"))
   } else {
-    tags$div(id = id, style = style, class = class)
+    tags$div(id = id, style = style, class = class,
+             "aria-labelledby" = paste0(id, "-aria"))
   }
 }
 

--- a/tests/testthat/test-htmlwidgets.R
+++ b/tests/testthat/test-htmlwidgets.R
@@ -33,7 +33,7 @@ test_that("New-style widget html methods do not trigger warning on non-tag outpu
 
 test_that("Fallback logic still works", {
   res <- widget_html("does_not_exist", "htmlwidgets", id = "id", style = NULL, class = NULL)
-  expect_identical(res, tags$div(id = "id"))
+  expect_identical(res, tags$div(id = "id", "aria-labelledby" = "id-aria"))
 })
 
 test_that("Legacy methods work with tagList() and HTML()", {


### PR DESCRIPTION
... to default widget_html() output.  

This will allow knitr to put `fig_alt` or `fig_cap` text on widgets as alternate text for accessibility purposes. 

The text is added unconditionally because I can't think of any likely bad effects it could have.  If used outside of `knitr` or with a`knitr` version prior to 1.42.12 it should have no effect unless there happens to be an HTML element with `id` equal to the widget id plus suffix "-aria", in which case that element will be the source of the alt text.  That seems very unlikely, and mostly harmless.

 Fixes #465 .