### PR TITLE
Remove use of html-fill-item-overflow-hidden class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,15 +21,13 @@ URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 Imports:
     grDevices,
-    htmltools (>= 0.5.4.9000),
+    htmltools (>= 0.5.7),
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),
     rmarkdown,
     yaml
 Suggests:
     testthat
-Remotes:
-    rstudio/htmltools
 Enhances: 
     shiny (>= 1.1)
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,13 +21,15 @@ URL: https://github.com/ramnathv/htmlwidgets
 BugReports: https://github.com/ramnathv/htmlwidgets/issues
 Imports:
     grDevices,
-    htmltools (>= 0.5.4),
+    htmltools (>= 0.5.4.9000),
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),
     rmarkdown,
     yaml
 Suggests:
     testthat
+Remotes:
+    rstudio/htmltools
 Enhances: 
     shiny (>= 1.1)
 VignetteBuilder: 

--- a/R/htmlwidgets.R
+++ b/R/htmlwidgets.R
@@ -183,14 +183,7 @@ toHTML <- function(x, standalone = FALSE, knitrOptions = NULL) {
       width = validateCssUnit(sizeInfo$width),
       height = validateCssUnit(sizeInfo$height),
     ),
-    class = paste(
-      name, "html-widget",
-      # bindFillRole() puts `overflow:auto` to items by default,
-      # which is a sensible generic default, but in the context of
-      # widgets, we can pretty easily run into non-pixel-perfect situations
-      # (e.g., the widget JS uses something like offsetHeight to resize itself)
-      if (sizeInfo$fill) "html-fill-item-overflow-hidden"
-    ),
+    class = paste(name, "html-widget"),
     width = sizeInfo$width,
     height = sizeInfo$height
   )
@@ -488,12 +481,7 @@ shinyWidgetOutput <- function(outputId, name, width, height, package = name,
     class = paste0(
       name, " html-widget html-widget-output",
       if (reportSize) " shiny-report-size",
-      if (reportTheme) " shiny-report-theme",
-      # bindFillRole() puts `overflow:auto` to items by default,
-      # which is a sensible generic default, but in the context of
-      # widgets, we can pretty easily run into non-pixel-perfect situations
-      # (e.g., the widget JS uses something like offsetHeight to resize itself)
-      if (fill) " html-fill-item-overflow-hidden"
+      if (reportTheme) " shiny-report-theme"
     ),
     style = css(
       width = validateCssUnit(width),


### PR DESCRIPTION
This is in response to https://github.com/rstudio/htmltools/pull/401, which removed the `overflow:auto` on fill items (and also removed the `html-fill-item-overflow-hidden` class since it's no longer relevant).