### PR TITLE
POSIXlt should not be evaluated in JS

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -162,6 +162,7 @@ JSEvals <- function(list) {
 #' @keywords internal
 shouldEval <- function(options) {
   if (is.list(options)) {
+    if (inherits(options, 'POSIXlt')) return(FALSE)
     if ((n <- length(options)) == 0) return(FALSE)
     # use numeric indices as names (remember JS indexes from 0, hence -1 here)
     if (is.null(names(options)))


### PR DESCRIPTION
This is to fix rstudio/DT#1092. `POSIXlt` is essentially a list, but we should stop the recursion here.