### PR TITLE
Replace resize event listeners with ResizeObserver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * htmlwidgets hex sticker added
 
+* Static widget resize detection now uses `ResizeObserver` instead of `window.resize`, Bootstrap tab/collapse, and ioslides event listeners. This enables widgets to detect container-level size changes (e.g., CSS-driven resizing, sidebar toggles, flexbox/grid layout changes) that were previously missed. (#496)
+
 # htmlwidgets 1.6.4
 
 This release reverts the change made in v1.6.3 (to no longer recurse into list-like objects when searching for JavaScript strings wrapped in `JS()`). Although that change helped prevent infinite recursion in some cases, it ultimately broke too many existing widgets that relied on the previous behavior. If you encounter infinite recursion errors ("C stack usage is too close to the limit"), the best strategy is to coerce the offending items to a character string. (#478)

--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -565,14 +565,15 @@
     }
   }
 
-  var resizeObserver = new ResizeObserver(function(entries) {
-    entries.forEach(function(entry) {
-      var resizeHandler = elementData(entry.target, "resize_handler");
-      if (resizeHandler) {
-        resizeHandler(entry);
-      }
-    });
-  });
+  var resizeObserver = typeof ResizeObserver !== "undefined" ?
+    new ResizeObserver(function(entries) {
+      entries.forEach(function(entry) {
+        var resizeHandler = elementData(entry.target, "resize_handler");
+        if (resizeHandler) {
+          resizeHandler(entry);
+        }
+      });
+    }) : null;
 
   // Render static widgets after the document finishes loading
   // Statically render all elements that are of this widget's class
@@ -605,7 +606,7 @@
 
         if (binding.resize) {
           var lastSize = getSize(el);
-          elementData(el, "resize_handler", function() {
+          var resizeHandler = function() {
             var size = getSize(el);
             if (size.w === 0 && size.h === 0)
               return;
@@ -613,8 +614,14 @@
               return;
             lastSize = size;
             binding.resize(el, size.w, size.h, initResult);
-          });
-          resizeObserver.observe(el);
+          };
+
+          if (resizeObserver) {
+            elementData(el, "resize_handler", resizeHandler);
+            resizeObserver.observe(el);
+          } else {
+            on(window, "resize", resizeHandler);
+          }
         }
 
         var scriptData = document.querySelector("script[data-for='" + el.id + "'][type='application/json']");

--- a/inst/www/htmlwidgets.js
+++ b/inst/www/htmlwidgets.js
@@ -565,6 +565,15 @@
     }
   }
 
+  var resizeObserver = new ResizeObserver(function(entries) {
+    entries.forEach(function(entry) {
+      var resizeHandler = elementData(entry.target, "resize_handler");
+      if (resizeHandler) {
+        resizeHandler(entry);
+      }
+    });
+  });
+
   // Render static widgets after the document finishes loading
   // Statically render all elements that are of this widget's class
   window.HTMLWidgets.staticRender = function() {
@@ -596,7 +605,7 @@
 
         if (binding.resize) {
           var lastSize = getSize(el);
-          var resizeHandler = function(e) {
+          elementData(el, "resize_handler", function() {
             var size = getSize(el);
             if (size.w === 0 && size.h === 0)
               return;
@@ -604,41 +613,8 @@
               return;
             lastSize = size;
             binding.resize(el, size.w, size.h, initResult);
-          };
-
-          on(window, "resize", resizeHandler);
-
-          // This is needed for cases where we're running in a Shiny
-          // app, but the widget itself is not a Shiny output, but
-          // rather a simple static widget. One example of this is
-          // an rmarkdown document that has runtime:shiny and widget
-          // that isn't in a render function. Shiny only knows to
-          // call resize handlers for Shiny outputs, not for static
-          // widgets, so we do it ourselves.
-          if (window.jQuery) {
-            window.jQuery(document).on(
-              "shown.htmlwidgets shown.bs.tab.htmlwidgets shown.bs.collapse.htmlwidgets",
-              resizeHandler
-            );
-            window.jQuery(document).on(
-              "hidden.htmlwidgets hidden.bs.tab.htmlwidgets hidden.bs.collapse.htmlwidgets",
-              resizeHandler
-            );
-          }
-
-          // This is needed for the specific case of ioslides, which
-          // flips slides between display:none and display:block.
-          // Ideally we would not have to have ioslide-specific code
-          // here, but rather have ioslides raise a generic event,
-          // but the rmarkdown package just went to CRAN so the
-          // window to getting that fixed may be long.
-          if (window.addEventListener) {
-            // It's OK to limit this to window.addEventListener
-            // browsers because ioslides itself only supports
-            // such browsers.
-            on(document, "slideenter", resizeHandler);
-            on(document, "slideleave", resizeHandler);
-          }
+          });
+          resizeObserver.observe(el);
         }
 
         var scriptData = document.querySelector("script[data-for='" + el.id + "'][type='application/json']");


### PR DESCRIPTION
## Summary
- Replace `window.resize`, Bootstrap tab/collapse, and ioslides event listeners with a single shared `ResizeObserver` for static widget resize detection
- Widgets now detect container-level size changes regardless of cause (CSS changes, flexbox/grid layout shifts, sidebar toggles, etc.)
- Net change: +12 lines, -36 lines in `inst/www/htmlwidgets.js`

## Motivation

The existing resize handling was written ~10 years ago before `ResizeObserver` existed. It relied on indirect proxies for size changes:
- `window.resize` — only fires on window-level changes
- Bootstrap `shown/hidden.bs.tab` and `shown/hidden.bs.collapse` — framework-specific
- ioslides `slideenter`/`slideleave` — presentation-specific

These miss common scenarios like a parent container changing size due to CSS, a sidebar toggle, or a flexbox/grid layout shift. `ResizeObserver` detects all of these directly.

## What changed

One `ResizeObserver` instance is created at module scope. Each static widget with a `resize` method is observed via `resizeObserver.observe(el)`. The existing guards (skip 0×0 dimensions, skip if unchanged) are preserved.

The Shiny widget path is unchanged — Shiny manages its own resize detection via `OutputBinding`.

## Browser support

`ResizeObserver` is supported in all evergreen browsers (96%+ global coverage). IE11 and older are not supported.

## Test plan

- [x] Window resize — widget resizes when browser window is resized
- [x] CSS container resize — widget resizes when parent container width changes (new behavior)
- [x] Show/hide toggle — widget renders with correct dimensions when revealed from `display:none`
- [x] Multiple widgets — several widgets on one page all resize independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)